### PR TITLE
Perform run-script checks even when running `make report`

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -778,54 +778,41 @@ litani-path:
 #	"make goto" to build the goto binary. Under the hood, this runs litani
 #	for just that proof.
 
+define run_custom_target =
+cd $(PROOF_ROOT); \
+./run-cbmc-proofs.py \
+  --target _$@ \
+  --proofs $(shell python3 -c
+    'import os.path; print(os.path.relpath("$(shell pwd)", "$(PROOF_ROOT)"))'
+  )
+endef
+
 _goto: $(HARNESS_GOTO).goto
 goto:
-	@ echo Running 'litani init'
-	$(LITANI) init --project $(PROJECT_NAME)
-	@ echo Running 'litani add-job'
-	$(MAKE) -B _goto
-	@ echo Running 'litani build'
-	$(LITANI) run-build
+	$(run_custom_target)
 
 _result: $(LOGDIR)/result.txt
 result:
-	@ echo Running 'litani init'
-	$(LITANI) init --project $(PROJECT_NAME)
-	@ echo Running 'litani add-job'
-	$(MAKE) -B _result
-	@ echo Running 'litani build'
-	$(LITANI) run-build
+	$(run_custom_target)
 
 _property: $(LOGDIR)/property.xml
 property:
-	@ echo Running 'litani init'
-	$(LITANI) init --project $(PROJECT_NAME)
-	@ echo Running 'litani add-job'
-	$(MAKE) -B _property
-	@ echo Running 'litani build'
-	$(LITANI) run-build
+	$(run_custom_target)
 
 _coverage: $(LOGDIR)/coverage.xml
 coverage:
-	@ echo Running 'litani init'
-	$(LITANI) init --project $(PROJECT_NAME)
-	@ echo Running 'litani add-job'
-	$(MAKE) -B _coverage
-	@ echo Running 'litani build'
-	$(LITANI) run-build
+	$(run_custom_target)
 
 _report1: $(PROOFDIR)/html
-_report2: $(PROOFDIR)/report
-_report:
-	cbmc-viewer --version >/dev/null 2>&1 && $(MAKE) -B _report2 || $(MAKE) -B _report1
+_report: $(PROOFDIR)/html
+report1:
+	$(run_custom_target)
+report:
+	$(run_custom_target)
 
-report report1 report2:
-	@ echo Running 'litani init'
-	$(LITANI) init --project $(PROJECT_NAME)
-	@ echo Running 'litani add-job'
-	$(MAKE) -B _report
-	@ echo Running 'litani build'
-	$(LITANI) run-build
+_report2: $(PROOFDIR)/report
+report2:
+	$(run_custom_target)
 
 ################################################################
 # Targets to clean up after ourselves

--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -863,38 +863,6 @@ veryclean: clean
 
 ################################################################
 
-# Rule for generating cbmc-batch.yaml, used by the CI at
-# https://github.com/awslabs/aws-batch-cbmc/
-
-JOB_OS ?= ubuntu16
-JOB_MEMORY ?= 32000
-
-# Proofs that are expected to fail should set EXPECTED to
-# "FAILED" in their Makefile. Values other than SUCCESSFUL
-# or FAILED will cause a CI error.
-EXPECTED ?= SUCCESSFUL
-
-define yaml_encode_options
-	"$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
-endef
-
-CI_FLAGS = $(CBMCFLAGS) $(CHECKFLAGS) $(COVERFLAGS)
-
-cbmc-batch.yaml:
-	@$(RM) $@
-	@echo 'build_memory: $(JOB_MEMORY)' > $@
-	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CI_FLAGS)))' >> $@
-	@echo 'coverage_memory: $(JOB_MEMORY)' >> $@
-	@echo 'expected: $(EXPECTED)' >> $@
-	@echo 'goto: $(HARNESS_GOTO).goto' >> $@
-	@echo 'jobos: $(JOB_OS)' >> $@
-	@echo 'property_memory: $(JOB_MEMORY)' >> $@
-	@echo 'report_memory: $(JOB_MEMORY)' >> $@
-
-.PHONY: cbmc-batch.yaml
-
-################################################################
-
 # Run "make echo-proof-uid" to print the proof ID of a proof. This can be
 # used by scripts to ensure that every proof has an ID, that there are
 # no duplicates, etc.


### PR DESCRIPTION
This PR ensures that running `make report` or another target in a proof
directory will run run-cbmc-proofs.py in the background, rather than
manually running Litani from the Makefile. The target to run is prefixed
with an underscore and passed to the run script, which will invoke make
in the proof directory only.

This ensures that the local proof-running experience matches CI as
closely as possible, since the run script contains sanity checks that
were not being run before this commit. As of this commit, developers who
run make in a proof directory (rather than running the run script) will
still get the benefits of the checks that the run script performs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
