### PR TITLE
add graphviz in README to avoid 'dot' not found

### DIFF
--- a/template-for-proof/README.md
+++ b/template-for-proof/README.md
@@ -6,7 +6,7 @@ This directory contains a memory safety proof for <__FUNCTION_NAME__>.
 To run the proof.
 -------------
 
-* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, and `cbmc-viewer`
+* Add `cbmc`, `goto-cc`, `goto-instrument`, `goto-analyzer`, `cbmc-viewer`, and `graphviz`
   to your path.
 * Run `make`.
 * Open html/index.html in a web browser.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Can't build(make) proof successfully with error info **FileNotFoundError: [Errno 2] No such file or directory: 'dot'**.
Add graphviz package in README for users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
