### PR TITLE
Simplify setup scripts

### DIFF
--- a/scripts/repository.py
+++ b/scripts/repository.py
@@ -1,0 +1,229 @@
+"""Discover repository properties like repository root, proof root, etc."""
+
+from pathlib import Path
+import subprocess
+import logging
+import json
+import re
+
+################################################################
+# Construct an ascending relative path like "../../.." from a
+# directory to an ancestor in the file system.
+#
+# The Path method dst.relative_to(src) requires that dst is a
+# descendant of src and will not produce a path like "../../..".
+
+def path_to_ancestor(descendant, ancestor):
+    """Relative path from descendant to ancestor."""
+
+    descendant = Path(descendant).resolve()
+    ancestor = Path(ancestor).resolve()
+
+    try:
+        path = descendant.relative_to(ancestor)
+    except ValueError:
+        raise UserWarning(f"{ancestor} is not an ancestor of {descendant}") from ValueError
+
+    return Path(*[Path('..') for part in path.parts])
+
+################################################################
+# Discover the roots of
+#   * the respository and
+#   * the proofs subtree installed by the starter kit.
+
+def repository_root(cwd='.', abspath=True):
+    """Path to root of repository containing current directory.
+
+    Return the absolute path if abspath is True.  If abspath is False,
+    return the relative path from the current directory.  If the
+    current directory is within a submodule of the repository, then
+    the root of the submodule is returned, not the repository itself.
+    """
+
+    cwd = Path(cwd).resolve()
+    for ancestor in [cwd, *cwd.parents]:
+        if (ancestor / '.git').is_dir():
+            return ancestor if abspath else path_to_ancestor(cwd, ancestor)
+    raise UserWarning(f"No git repository contains {cwd}")
+
+def proofs_root(cwd='.', abspath=True):
+    """Path to root of proofs subtree installed by starter kit.
+
+    Return an absolute path if abspath is True, and a path relative to
+    cwd otherwise.  Search starts at cwd and ascends until it reaches
+    the root of the enclosing repository, and raises UserWarning if
+    there is no enclosing repository."""
+
+    cwd = Path(cwd).resolve()                     # Where to start looking
+    root = repository_root(cwd=cwd, abspath=True) # Where to stop looking
+    proofs = "proofs"                             # What to look for
+
+    for path in [cwd, *cwd.parents]:
+        if path.name == proofs:
+            return path if abspath else path_to_ancestor(cwd, path)
+        if path == root:
+            break
+    raise UserWarning(f"'{cwd}' has no ancestor named '{proofs}'")
+
+################################################################
+# Discover the roots of
+#   * the litani submodule
+#   * the starter kit submodule
+
+def load_submodules(repo=None):
+    """Load file .gitmodules describing the installed submodules"""
+
+    repo = repo or repository_root()
+    try:
+        cmd = ['git', 'config', '-f', '.gitmodules', '--list']
+        kwds = {'cwd': str(repo), 'capture_output': True, 'text': True}
+        lines = subprocess.run(cmd, **kwds, check=True).stdout.splitlines()
+    except subprocess.CalledProcessError as error:
+        logging.debug(error)
+        raise UserWarning(
+            f"Can't load submodules in repository root '{repo}'"
+        ) from error
+
+    submodules = {}
+    for line in lines:
+        line=re.sub(r'\s+', ' ', line.strip())
+
+        # Output of git config is lines of the form
+        #   submodule.ORGANIZATION/REPOSITORY.path=PATH
+        #   submodule.ORGANIZATION/REPOSITORY.url=URL
+        match = re.match(r"^submodule\.([^=]+)\.([^=]+) *= *(.+)", line)
+        if not match:
+            logging.debug("Can't parse git config output: '%s'", line)
+            continue
+
+        name, key, value = [string.strip() for string in match.groups()[0:3]]
+        submodules[name] = submodules.get(name, {})
+        submodules[name][key] = value
+    return submodules
+
+def submodule_root(url, submodules=None, repo=None, abspath=True):
+    """Look up path to root of submodule url in submodules."""
+
+    url = url.lower()
+    repo = repo or repository_root()
+    submodules = submodules or load_submodules(repo=repo)
+
+    for _, config in submodules.items():
+        config_url = config.get("url")
+        config_path = config.get("path")
+
+        if not config_url or not config_url.lower() in [url, url+".git"]:
+            continue
+        if not config_path:
+            logging.debug("Found submodule config = %s", config)
+            raise UserWarning(f"Can't find path to submodule '{url}'")
+        return Path(repo/config_path if abspath else config_path)
+
+    logging.debug("Found submodules = %s", submodules)
+    raise UserWarning(f"Can't find submodule '{url}'")
+
+def litani_root(submodules=None, repo=None, abspath=True):
+    """Root of litani submodule."""
+
+    litani = 'https://github.com/awslabs/aws-build-accumulator'
+    return submodule_root(litani, submodules, repo, abspath)
+
+def starter_kit_root(submodules=None, repo=None, abspath=True):
+    """Root of starter kit submodule."""
+
+    old_starter = 'https://github.com/awslabs/aws-templates-for-cbmc-proofs'
+    new_starter = 'https://github.com/model-checking/cbmc-starter-kit'
+    return (submodule_root(old_starter, submodules, repo, abspath) or
+            submodule_root(new_starter, submodules, repo, abspath))
+
+################################################################
+# Discover the set of all source files in the repository that define a
+# function named func.
+
+def repo_sources(repo='.'):
+    """Paths to all source files within a repository.
+
+    Return a list of paths to C source files found under the
+    repository root (paths are relative to the repository root)."""
+
+    repo = Path(repo).resolve()
+    try:
+        cmd = ['find', '.', '-name', '*.c']
+        kwds = {'cwd': repo, 'capture_output': True, 'text': True}
+        return subprocess.run(cmd, **kwds, check=True).stdout.splitlines()
+    except subprocess.CalledProcessError as error:
+        logging.debug("Failed to run find in %s", repo)
+        logging.debug(error)
+        return []
+
+def function_tags(sources, repo='.'):
+    """Tags for all function definitions in source files.
+
+    Return a list of function definitions found in a list of source
+    files.  Restrict source files to existing files under the root repo.
+    Describe each function definition with a dict
+      {"name": function_name, "path": source_path}
+    giving the function name and the path to the defining source file."""
+
+    def sources_under_root(sources, repo):
+        """Restrict sources to paths under repo relative to repo."""
+
+        srcs = []
+        for src in sources:
+            path = (repo / src).resolve()
+            try:
+                if not path.is_file():
+                    raise ValueError
+                srcs.append(path.relative_to(repo))
+            except ValueError: # path is not a file or not relative to repo
+                logging.debug("Skipping %s: not a file under %s", src, repo)
+                continue
+        return [str(src) for src in srcs]
+
+    repo = Path(repo).resolve()
+    sources = sources_under_root(sources, repo)
+    try:
+        cmd = [
+            'ctags',
+            '--c-types=f', # include only function definition tags
+            '--output-format=json', # each line is one json blob for one tag
+            '--fields=NF' # each json blob is {name="function", path="source"}
+        ] + sources
+        kwds = {'cwd': repo, 'capture_output': True, 'text': True}
+        lines = subprocess.run(cmd, **kwds, check=True).stdout.splitlines()
+        return json.loads(f"[{','.join(lines)}]")
+    except subprocess.CalledProcessError as error:
+        logging.debug("Can't run ctags in %s", repo)
+        logging.debug(error)
+        return []
+    except json.decoder.JSONDecodeError as error:
+        logging.debug("Can't load json output of ctags in %s", repo)
+        logging.debug(error)
+        return []
+
+def function_paths(func, tags):
+    """Paths to all source files in tags defining a function func."""
+
+    return sorted([tag['path'] for tag in tags if tag['name'] == func])
+
+def function_sources(func, cwd='.', repo='.', abspath=True):
+    """Paths to all source files in the repository defining a function func.
+
+    Paths are absolute if abspath is True, and relative to cwd otherwise.
+
+    """
+
+    cwd = Path(cwd).resolve()
+    repo = Path(repo).resolve()
+
+    sources = repo_sources(repo)
+    tags = function_tags(sources, repo)
+    paths = function_paths(func, tags)
+
+    path_to_repo = repo if abspath else path_to_ancestor(cwd, repo)
+    sources = [Path(path_to_repo, path) for path in paths]
+
+    assert all(src.is_file() for src in sources)
+    return sources
+
+################################################################

--- a/scripts/setup-proof.py
+++ b/scripts/setup-proof.py
@@ -9,6 +9,7 @@ import logging
 import os
 import shutil
 
+import repository
 import util
 
 def proof_template_filenames():
@@ -48,10 +49,10 @@ def main():
 
     logging.basicConfig(format='%(levelname)s: %(message)s')
 
-    function = util.read_function_name()
-    source_file = util.read_source_path()
-    source_root = util.read_source_root_path()
-    proof_root = util.read_proof_root_path()
+    function = util.ask_for_function_name()
+    source_file = util.ask_for_source_file(function)
+    source_root = repository.repository_root()
+    proof_root = repository.proofs_root()
 
     proof_dir = os.path.abspath(function)
     os.mkdir(proof_dir)

--- a/scripts/setup-proof.py
+++ b/scripts/setup-proof.py
@@ -18,16 +18,16 @@ def proof_template_filenames():
 
 def read_proof_template(filename):
     directory = os.path.join(util.templates_root(), util.PROOF_TEMPLATES)
-    with open(os.path.join(directory, filename)) as data:
+    with open(os.path.join(directory, filename), encoding='utf-8') as data:
         return data.read().splitlines()
 
 def write_proof_template(lines, filename, directory):
-    with open(os.path.join(directory, filename), "w") as data:
+    with open(os.path.join(directory, filename), "w", encoding='utf-8') as data:
         data.writelines(line + '\n' for line in lines)
 
 def rename_proof_harness(function, directory):
     shutil.move(os.path.join(directory, "FUNCTION_harness.c"),
-                os.path.join(directory, "{}_harness.c".format(function)))
+                os.path.join(directory, f"{function}_harness.c"))
 
 def patch_function_name(lines, function):
     return [line.replace("<__FUNCTION_NAME__>", function) for line in lines]

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -5,9 +5,11 @@
 
 """Set up the CBMC proof instrastructure."""
 
+from pathlib import Path
 import logging
 import os
 
+import repository
 import util
 
 SRCDIR_TEXT = """
@@ -52,19 +54,11 @@ def main():
 
     logging.basicConfig(format='%(levelname)s: %(message)s')
 
-    source_root = util.read_source_root_path()
-
-    # the script is being run in the cbmc root
-    cbmc_root = os.path.abspath('.')
-
-    # the script is creating the proof root
-    proof_root = os.path.abspath('proofs')
-
-    # the script is linking to the litani script within the litani submodule
-    litani = util.read_litani_path()
-
-    # the name of the project used in project verification reports
-    project_name = util.read_project_name()
+    cbmc_root = Path.cwd()
+    proof_root = cbmc_root / "proofs"
+    source_root = repository.repository_root()
+    litani = repository.litani_root() / 'litani'
+    project_name = util.ask_for_project_name()
 
     util.copy_repository_templates(cbmc_root)
     create_makefile_template_defines(

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -42,7 +42,7 @@ def create_makefile_template_defines(
     if os.path.exists(makefile):
         logging.warning("Overwriting %s", makefile)
 
-    with open(makefile, "w") as fileobj:
+    with open(makefile, "w", encoding='utf-8') as fileobj:
         print(SRCDIR_TEXT.format(os.path.relpath(source_root, proof_root)),
               file=fileobj)
         print(LITANI_TEXT.format(os.path.relpath(litani, proof_root)),
@@ -62,7 +62,8 @@ def main():
 
     util.copy_repository_templates(cbmc_root)
     create_makefile_template_defines(
-        proof_root, source_root, litani, project_name)
+        proof_root, source_root, litani, project_name
+    )
 
 if __name__ == "__main__":
     main()

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -119,7 +119,7 @@ def link_files(name, src, dst):
     install_method[1](src_link, dst_name)
     return 0
 
-def copy_directory_contents(src, dst):
+def copy_directory_contents(src, dst, exclude=None):
     """Link the contents of one directory into another."""
 
     src = os.path.normpath(src)
@@ -131,6 +131,8 @@ def copy_directory_contents(src, dst):
     skipped = 0
     for name in files_under_root(src):
         name = os.path.normpath(name)
+        if exclude and name.startswith(exclude):
+            continue
         skipped += link_files(name, src, dst)
 
     if skipped:
@@ -142,4 +144,5 @@ def copy_repository_templates(cbmc_root):
 
     copy_directory_contents(os.path.join(templates_root(),
                                          REPOSITORY_TEMPLATES),
-                            cbmc_root)
+                            cbmc_root,
+                            exclude="negative_tests")

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -114,7 +114,7 @@ def link_files(name, src, dst):
                         install_method[0], name, src_link)
         return 1
 
-    logging.warning(
+    logging.debug(
         "Creating %s %s -> %s", install_method[0], name, src_link)
     install_method[1](src_link, dst_name)
     return 0


### PR DESCRIPTION
This pull request simplifies the setup scripts by adding functions that answer most of the questions about the repository layout that they have been asking the user.   Examples are the location of the repository root, the proof root, and the litani submodule.  Adding the starter kit to a project and configuring for a proof of pvPortMalloc in FreeRTOS is now just

```
cbmc: ./starter-kit/scripts/setup.py 
What is the project name? Kernel
cbmc: cd proofs/

cbmc/proofs: ../starter-kit/scripts/setup-proof.py 
What is the function name? pvPortMalloc
These source files define a function 'pvPortMalloc':
   0 ../../../portable/ARMv8M/secure/heap/secure_heap.c
   1 ../../../portable/GCC/ARM_CM23/secure/secure_heap.c
   2 ../../../portable/GCC/ARM_CM33/secure/secure_heap.c
   3 ../../../portable/IAR/ARM_CM23/secure/secure_heap.c
   4 ../../../portable/IAR/ARM_CM33/secure/secure_heap.c
   5 ../../../portable/MemMang/heap_1.c
   6 ../../../portable/MemMang/heap_2.c
   7 ../../../portable/MemMang/heap_3.c
   8 ../../../portable/MemMang/heap_4.c
   9 ../../../portable/MemMang/heap_5.c
  10 ../../../portable/WizC/PIC18/port.c
  11 The source file is not listed here
Select a source file (the options are 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11): 9
cbmc/proofs: cd pvPortMalloc

cbmc/proofs/pvPortMalloc: make
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
