### PR TITLE
Add support for remove-static via crangler

### DIFF
--- a/src/cbmc_starter_kit/template-for-proof/Makefile
+++ b/src/cbmc_starter_kit/template-for-proof/Makefile
@@ -23,13 +23,13 @@ PROJECT_SOURCES += $(SRCDIR)/<__PATH_TO_SOURCE_FILE__>
 # If you require access to a file-local ("static") function or object to conduct
 # your proof, set the following (and do not include the original source file
 # ("<__PATH_TO_SOURCE_FILE__>") in PROJECT_SOURCES).
-# REMOVE_STATIC = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# REWRITTEN_SOURCES = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
 # include <__PATH_TO_MAKEFILE__>/Makefile.common
 # $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/<__PATH_TO_SOURCE_FILE__>
 # $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
 # $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
-# Care is required with variables on the left-hand side: REMOVE_STATIC must be
-# set before including Makefile.common, but any use of variables on the
+# Care is required with variables on the left-hand side: REWRITTEN_SOURCES must
+# be set before including Makefile.common, but any use of variables on the
 # left-hand side requires those variables to be defined. Hence, _SOURCE,
 # _FUNCTIONS, _OBJECTS is set after including Makefile.common.
 

--- a/src/cbmc_starter_kit/template-for-proof/Makefile
+++ b/src/cbmc_starter_kit/template-for-proof/Makefile
@@ -20,4 +20,17 @@ PROJECT_SOURCES += $(SRCDIR)/<__PATH_TO_SOURCE_FILE__>
 # documentation in Makefile.common under the "Job Pools" heading for details.
 # EXPENSIVE = true
 
+# If you require access to a file-local ("static") function or object to conduct
+# your proof, set the following (and do not include the original source file
+# ("<__PATH_TO_SOURCE_FILE__>") in PROJECT_SOURCES).
+# REMOVE_STATIC = $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i
+# include <__PATH_TO_MAKEFILE__>/Makefile.common
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_SOURCE = $(SRCDIR)/<__PATH_TO_SOURCE_FILE__>
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_FUNCTIONS = foo bar
+# $(PROOFDIR)/<__SOURCE_FILE_BASENAME__>.i_OBJECTS = baz
+# Care is required with variables on the left-hand side: REMOVE_STATIC must be
+# set before including Makefile.common, but any use of variables on the
+# left-hand side requires those variables to be defined. Hence, _SOURCE,
+# _FUNCTIONS, _OBJECTS is set after including Makefile.common.
+
 include <__PATH_TO_MAKEFILE__>/Makefile.common

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile-project-defines
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile-project-defines
@@ -16,6 +16,11 @@
 # Flags to pass to goto-cc for linking (typically those passed to gcc)
 # LINK_FLAGS =
 
+# Flag to pass to goto-cc to make all static symbols globally visible. Leave it
+# unset or set it to --export-file-local-symbols to enable this behavior. Else,
+# selectively enable access to such symbols via each proof's Makefile.
+EXPORT_FILE_LOCAL_SYMBOLS =
+
 # Preprocessor include paths -I...
 # Consider adding
 #     INCLUDES += -I$(CBMC_ROOT)/include

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -491,7 +491,7 @@ CBMC_RESTRICT_FUNCTION_POINTER := $(patsubst %,--restrict-function-pointer %, $(
 
 # Construct crangler configuration files
 #
-# REMOVE_STATIC is a list of crangler output files source.i.
+# REWRITTEN_SOURCES is a list of crangler output files source.i.
 # This target assumes that for each source.i
 #   * source.i_SOURCE is the path to a source file,
 #   * source.i_FUNCTIONS is a list of functions (may be empty)
@@ -524,8 +524,8 @@ CBMC_RESTRICT_FUNCTION_POINTER := $(patsubst %,--restrict-function-pointer %, $(
 # Makefile.common, these definitions must appear after the inclusion
 # of Makefile.common in the proof Makefile.
 #
-$(foreach rs,$(REMOVE_STATIC),$(eval $(rs).json: $($(rs)_SOURCE)))
-$(foreach rs,$(REMOVE_STATIC),$(rs).json):
+$(foreach rs,$(REWRITTEN_SOURCES),$(eval $(rs).json: $($(rs)_SOURCE)))
+$(foreach rs,$(REWRITTEN_SOURCES),$(rs).json):
 	echo '{'\
 	  '"sources": ['\
 	  '"$($(@:.json=)_SOURCE)"'\
@@ -551,8 +551,8 @@ $(foreach rs,$(REMOVE_STATIC),$(rs).json):
 
 # Rewrite source files with crangler
 #
-$(foreach rs,$(REMOVE_STATIC),$(eval $(rs): $(rs).json))
-$(REMOVE_STATIC):
+$(foreach rs,$(REWRITTEN_SOURCES),$(eval $(rs): $(rs).json))
+$(REWRITTEN_SOURCES):
 	$(LITANI) add-job \
 	  --command \
 	  '$(CRANGLER) $@.json' \
@@ -568,7 +568,7 @@ $(REMOVE_STATIC):
 # Build targets that make the relevant .goto files
 
 # Compile project sources
-$(PROJECT_GOTO)1.goto: $(PROJECT_SOURCES) $(REMOVE_STATIC)
+$(PROJECT_GOTO)1.goto: $(PROJECT_SOURCES) $(REWRITTEN_SOURCES)
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_CC) $(CBMC_VERBOSITY) $(COMPILE_FLAGS) $(EXPORT_FILE_LOCAL_SYMBOLS) $(INCLUDES) $(DEFINES) $^ -o $@' \
@@ -916,7 +916,7 @@ clean:
 	-$(RM) $(DEPENDENT_GOTOS)
 	-$(RM) TAGS*
 	-$(RM) *~ \#*
-	-$(RM) $(REMOVE_STATIC) $(foreach rs,$(REMOVE_STATIC),$(rs).json)
+	-$(RM) $(REWRITTEN_SOURCES) $(foreach rs,$(REWRITTEN_SOURCES),$(rs).json)
 
 veryclean: clean
 	-$(RM) -r html report

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -439,6 +439,7 @@ CBMC ?= cbmc
 GOTO_ANALYZER ?= goto-analyzer
 GOTO_CC ?= goto-cc
 GOTO_INSTRUMENT ?= goto-instrument
+CRANGLER ?= crangler
 VIEWER ?= cbmc-viewer
 MAKE_SOURCE ?= make-source
 VIEWER2 ?= cbmc-viewer
@@ -487,8 +488,47 @@ CBMC_RESTRICT_FUNCTION_POINTER := $(patsubst %,--restrict-function-pointer %, $(
 ################################################################
 # Build targets that make the relevant .goto files
 
+# Create preprocessed files with "static" selectively removed via crangler
+$(foreach rs,$(REMOVE_STATIC),$(eval $(rs).json: $($(rs)_SOURCE)))
+$(foreach rs,$(REMOVE_STATIC),$(rs).json):
+	echo '{'\
+	  '"sources": ['\
+	  '"$($(@:.json=)_SOURCE)"'\
+	  '],'\
+	  '"includes": ['\
+	    '$(subst $(SPACE),$(COMMA),$(patsubst -I%,"%",$(strip $(INCLUDES))))' \
+	  '],'\
+	  '"defines": ['\
+	    '$(subst $(SPACE),$(COMMA),$(patsubst -D%,"%",$(subst ",\",$(strip $(DEFINES)))))' \
+	  '],'\
+	  '"functions": ['\
+	    '{'\
+	      '$(subst ~, ,$(subst $(SPACE),$(COMMA),$(patsubst %,"%":["remove~static"],$($(@:.json=)_FUNCTIONS))))' \
+	    '}'\
+	  '],'\
+	  '"objects": ['\
+	    '{'\
+	      '$(subst ~, ,$(subst $(SPACE),$(COMMA),$(patsubst %,"%":["remove~static"],$($(@:.json=)_OBJECTS))))' \
+	    '}'\
+	  '],'\
+	  '"output": "$(@:.json=)"'\
+	'}' > $@
+
+$(foreach rs,$(REMOVE_STATIC),$(eval $(rs): $(rs).json))
+$(REMOVE_STATIC):
+	$(LITANI) add-job \
+	  --command \
+	  '$(CRANGLER) $@.json' \
+	  --inputs $($@_SOURCE) \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/project_sources-log.txt \
+	  --interleave-stdout-stderr \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): removing static"
+
 # Compile project sources
-$(PROJECT_GOTO)1.goto: $(PROJECT_SOURCES)
+$(PROJECT_GOTO)1.goto: $(PROJECT_SOURCES) $(REMOVE_STATIC)
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_CC) $(CBMC_VERBOSITY) --export-file-local-symbols $(COMPILE_FLAGS) $(INCLUDES) $(DEFINES) $^ -o $@' \
@@ -836,6 +876,7 @@ clean:
 	-$(RM) $(DEPENDENT_GOTOS)
 	-$(RM) TAGS*
 	-$(RM) *~ \#*
+	-$(RM) $(REMOVE_STATIC) $(foreach rs,$(REMOVE_STATIC),$(rs).json)
 
 veryclean: clean
 	-$(RM) -r html report

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -487,9 +487,43 @@ CBMC_REMOVE_FUNCTION_BODY := $(patsubst %,--remove-function-body %, $(REMOVE_FUN
 CBMC_RESTRICT_FUNCTION_POINTER := $(patsubst %,--restrict-function-pointer %, $(RESTRICT_FUNCTION_POINTER))
 
 ################################################################
-# Build targets that make the relevant .goto files
+# Targets for rewriting source files with crangler
 
-# Create preprocessed files with "static" selectively removed via crangler
+# Construct crangler configuration files
+#
+# REMOVE_STATIC is a list of crangler output files source.i.
+# This target assumes that for each source.i
+#   * source.i_SOURCE is the path to a source file,
+#   * source.i_FUNCTIONS is a list of functions (may be empty)
+#   * source.i_OBJECTS is a list of variables (may be empty)
+# This target constructs the crangler configuration file source.i.json
+# of the form
+#   {
+#     "sources":   [ "/proj/code.c" ],
+#     "includes":  [ "/proj/include" ],
+#     "defines":   [ "VAR=1" ],
+#     "functions": [ {"function_name": ["remove static"]} ],
+#     "objects":   [ {"variable_name": ["remove static"]} ],
+#     "output":    "source.i"
+#   }
+# to remove the static attribute from function_name and variable_name
+# in the source file source.c and write the result to source.i.
+#
+# This target assumes that filenames include no spaces and that
+# the INCLUDES and DEFINES variables include no spaces after -I
+# and -D.  For example, use "-DVAR=1" and not "-D VAR=1".
+#
+# Define *_SOURCE, *_FUNCTIONS, and *_OBJECTS in the proof Makefile.
+# The string source.i is usually an absolute path $(PROOFDIR)/code.i
+# to a file in the proof directory that contains the proof Makefile.
+# The proof Makefile usually includes the definitions
+#   $(PROOFDIR)/code.i_SOURCE = /proj/code.c
+#   $(PROOFDIR)/code.i_FUNCTIONS = function_name
+#   $(PROOFDIR)/code.i_OBJECTS = variable_name
+# Because these definitions refer to PROOFDIR that is defined in this
+# Makefile.common, these definitions must appear after the inclusion
+# of Makefile.common in the proof Makefile.
+#
 $(foreach rs,$(REMOVE_STATIC),$(eval $(rs).json: $($(rs)_SOURCE)))
 $(foreach rs,$(REMOVE_STATIC),$(rs).json):
 	echo '{'\
@@ -515,6 +549,8 @@ $(foreach rs,$(REMOVE_STATIC),$(rs).json):
 	  '"output": "$(@:.json=)"'\
 	'}' > $@
 
+# Rewrite source files with crangler
+#
 $(foreach rs,$(REMOVE_STATIC),$(eval $(rs): $(rs).json))
 $(REMOVE_STATIC):
 	$(LITANI) add-job \
@@ -522,11 +558,14 @@ $(REMOVE_STATIC):
 	  '$(CRANGLER) $@.json' \
 	  --inputs $($@_SOURCE) \
 	  --outputs $@ \
-	  --stdout-file $(LOGDIR)/project_sources-log.txt \
+	  --stdout-file $(LOGDIR)/crangler-$(subst /,_,$(subst .,_,$@))-log.txt \
 	  --interleave-stdout-stderr \
 	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage build \
 	  --description "$(PROOF_UID): removing static"
+
+################################################################
+# Build targets that make the relevant .goto files
 
 # Compile project sources
 $(PROJECT_GOTO)1.goto: $(PROJECT_SOURCES) $(REMOVE_STATIC)

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -309,6 +309,7 @@ NONDET_STATIC ?=
 # Flags to pass to goto-cc for compilation and linking
 COMPILE_FLAGS ?= -Wall
 LINK_FLAGS ?= -Wall
+EXPORT_FILE_LOCAL_SYMBOLS ?= --export-file-local-symbols
 
 # Preprocessor include paths -I...
 INCLUDES ?=
@@ -531,7 +532,7 @@ $(REMOVE_STATIC):
 $(PROJECT_GOTO)1.goto: $(PROJECT_SOURCES) $(REMOVE_STATIC)
 	$(LITANI) add-job \
 	  --command \
-	    '$(GOTO_CC) $(CBMC_VERBOSITY) --export-file-local-symbols $(COMPILE_FLAGS) $(INCLUDES) $(DEFINES) $^ -o $@' \
+	    '$(GOTO_CC) $(CBMC_VERBOSITY) $(COMPILE_FLAGS) $(EXPORT_FILE_LOCAL_SYMBOLS) $(INCLUDES) $(DEFINES) $^ -o $@' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --stdout-file $(LOGDIR)/project_sources-log.txt \
@@ -543,7 +544,7 @@ $(PROJECT_GOTO)1.goto: $(PROJECT_SOURCES) $(REMOVE_STATIC)
 $(PROOF_GOTO)1.goto: $(PROOF_SOURCES)
 	$(LITANI) add-job \
 	  --command \
-	    '$(GOTO_CC) $(CBMC_VERBOSITY) --export-file-local-symbols $(COMPILE_FLAGS) $(INCLUDES) $(DEFINES) $^ -o $@' \
+	    '$(GOTO_CC) $(CBMC_VERBOSITY) $(COMPILE_FLAGS) $(EXPORT_FILE_LOCAL_SYMBOLS) $(INCLUDES) $(DEFINES) $^ -o $@' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --stdout-file $(LOGDIR)/proof_sources-log.txt \


### PR DESCRIPTION
crangler is a utility shipped with CBMC that permits (among other
features) selective removal of "static" from functions and objects via
JSON configuration files. From CBMC's perspective this is the preferred
route forward instead of using --export-file-local-symbols. Key
advantages are that selective removal is possible, and that there is no
renaming of functions. The latter makes for more intuitive proof
harnesses.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
