### PR TITLE
Invoke viewer with full path to cbmc-viewer.json configuration file

### DIFF
--- a/template-for-repository/proofs/Makefile.common
+++ b/template-for-repository/proofs/Makefile.common
@@ -777,7 +777,8 @@ define VIEWER2_CMD
     --property $(LOGDIR)/property.xml \
     --srcdir $(SRCDIR) \
     --goto $(HARNESS_GOTO).goto \
-    --reportdir $(PROOFDIR)/report
+    --reportdir $(PROOFDIR)/report \
+    --config $(PROOFDIR)/cbmc-viewer.json
 endef
 export VIEWER2_CMD
 


### PR DESCRIPTION
This patch adds to the viewer invocation the --config option with the
absolute path to the cbmc-viewer.json configuration file.

The run-cbmc-proofs script invokes viewer from the top-level proof
root with the absolute paths to the cbmc output.  Viewer by default
looks for the cbmc-viewer.json configuration file in the current
working directory.  This default behavior works when viewer is invoked
in the proof directory, but not in the proof root.  This patch fixes
this problem by overriding the default behavior and giving the
absolute path to the file.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
