### PR TITLE
Publish via the documentation branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: MIT
 
 name: Publish cbmc-starter-kit documentation
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'documentation'
 
 jobs:
   publish:
@@ -18,8 +21,10 @@ jobs:
         run: cd docs && mdbook build && touch book/.nojekyll
 
       - name: Publish documentation
-        if: ${{ github.event_name == 'push' && startsWith('refs/heads/master', github.ref) }}
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages
           folder: docs/book/
+
+# This conditional might be useful on the publish step in the future
+#       if: ${{ github.event_name == 'push' && startsWith('refs/heads/master', github.ref) }}


### PR DESCRIPTION
Publish documentation via the documentation branch until it is ready to be merged into master.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
