### PR TITLE
Modify loop unwinding and general cleanup in Makefile.common

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 
 [metadata]
 name = cbmc-starter-kit
-version = 2.1.1
+version = 2.2
 author = Mark R. Tuttle
 author_email = mrtuttle@amazon.com
 description = CBMC starter kit makes it easy to add CBMC verification to a software project

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -336,6 +336,22 @@ CBMC_OBJECT_BITS ?= 8
 # of times CBMC actually unwinds the loop.
 UNWINDSET ?=
 
+# CBMC early loop unwinding (Normally set in the proof Makefile)
+#
+# Most users can ignore this variable.
+#
+# This variable exists to support the use of loop and function
+# contracts, two features under development for CBMC.  Checking the
+# assigns clause for function contracts and loop invariants currently
+# assumes loop-free bodies for loops and functions with contracts
+# (possibly after replacing nested loops with their own loop
+# contracts).  To satisfy this requirement, it may be necessary to
+# unwind some loops before the function contract and loop invariant
+# transformations are applied to the goto program.  This variable
+# EARLY_UNWINDSET is identical to UNWINDSET, and we assume that the
+# loops mentioned in EARLY_UNWINDSET and UNWINDSET are disjoint.
+EARLY_UNWINDSET ?=
+
 # CBMC function removal (Normally set set in the proof Makefile)
 #
 # REMOVE_FUNCTION_BODY is a list of function names.  CBMC will "undefine"
@@ -459,6 +475,12 @@ ifdef UNWINDSET
     CBMC_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(UNWINDSET)))
   endif
 endif
+ifdef EARLY_UNWINDSET
+  ifneq ($(strip $(EARLY_UNWINDSET)),"")
+    CBMC_EARLY_UNWINDSET := --unwindset $(subst $(SPACE),$(COMMA),$(strip $(EARLY_UNWINDSET)))
+  endif
+endif
+
 CBMC_REMOVE_FUNCTION_BODY := $(patsubst %,--remove-function-body %, $(REMOVE_FUNCTION_BODY))
 CBMC_RESTRICT_FUNCTION_POINTER := $(patsubst %,--restrict-function-pointer %, $(RESTRICT_FUNCTION_POINTER))
 
@@ -583,8 +605,21 @@ $(HARNESS_GOTO)6.goto: $(HARNESS_GOTO)5.goto
 	  --ci-stage build \
 	  --description "$(PROOF_UID): replacing function calls with function contracts"
 
+# Optionally unwind loops for loop and function contracts
+$(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
+	$(LITANI) add-job \
+	  --command \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_EARLY_UNWINDSET) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $^ $@' \
+	  --inputs $^ \
+	  --outputs $@ \
+	  --stdout-file $(LOGDIR)/unwind_loops-log.txt \
+	  --interleave-stdout-stderr \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --ci-stage build \
+	  --description "$(PROOF_UID): unwinding loops"
+
 # Optionally apply loop contracts
-$(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)6.goto
+$(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)7.goto
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_APPLY_LOOP_CONTRACTS) $^ $@' \

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -7,47 +7,86 @@
 CBMC_STARTER_KIT_VERSION = _CBMC_STARTER_KIT_VERSION_
 
 ################################################################
-# This file Makefile.common defines the basic work flow for cbmc proofs.
+# The CBMC Starter Kit depends on the files Makefile.common and
+# run-cbmc-proofs.py.  They are installed by the setup script
+# cbmc-starter-kit-setup and updated to the latest version by the
+# update script cbmc-starter-kit-update.  For more information about
+# the starter kit and these files and these scripts, see
+# https://model-checking.github.io/cbmc-starter-kit
 #
-# The intention is that the goal of your project is to write proofs
-# for a collection of functions in a source tree.
+# Makefile.common implements what we consider to be some best
+# practices for using cbmc for software verification.
 #
-# To use this file
-#   1. Edit the variable definitions in Section I below as appropriate for
-#      your project, your proofs, and your source tree.
-#   2. For each function for which you are writing a proof,
-#      a. Create a subdirectory <DIR>.
-#      b. Write a proof harness (a function) with the name <HARNESS_ENTRY>
-#         in a file with the name <DIR>/<HARNESS_FILE>.c
-#      c. Write a makefile with the name <DIR>/Makefile that looks
-#         something like
+# Section I gives default values for a large number of Makefile
+# variables that control
+#   * how your code is built (include paths, etc),
+#   * what program transformations are applied to your code (loop
+#     unwinding, etc), and
+#   * what properties cbmc checks for in your code (memory safety, etc).
 #
-#         HARNESS_FILE=<HARNESS_FILE>
-#         HARNESS_ENTRY=<HARNESS_ENTRY>
-#         PROOF_UID=<PROOF_UID>
+# These variables are defined below with definitions of the form
+#   VARIABLE ?= DEFAULT_VALUE
+# meaning VARIABLE is set to DEFAULT_VALUE if VARIABLE has not already
+# been given a value.
 #
-#         PROJECT_SOURCES += $(SRCDIR)/libraries/api_1.c
-#         PROJECT_SOURCES += $(SRCDIR)/libraries/api_2.c
+# For your project, you can override these default values with
+# project-specific definitions in Makefile-project-defines.
 #
-#         PROOF_SOURCES += $(PROOFDIR)/harness.c
-#         PROOF_SOURCES += $(SRCDIR)/cbmc/proofs/stub_a.c
-#         PROOF_SOURCES += $(SRCDIR)/cbmc/proofs/stub_b.c
+# For any individual proof, you can override these default values and
+# project-specific values with proof-specific definitions in the
+# Makefile for your proof.
 #
-#         UNWINDSET += foo.0:3
-#         UNWINDSET += bar.1:6
+# The definitions in the proof Makefile override definitions in the
+# project Makefile-project-defines which override definitions in this
+# Makefile.common.
 #
-#         REMOVE_FUNCTION_BODY += api_stub_a
-#         REMOVE_FUNCTION_BODY += api_stub_b
+# Section II uses the values defined in Section I to build your code, run
+# your proof, and build a report of your results.  You should not need
+# to modify or override anything in Section II, but you may want to
+# read it to understand how the values defined in Section I control
+# things.
 #
-#         DEFINES = -DDEBUG=0
+# To use Makefile.common, set variables as describe above as needed,
+# and then for each proof,
 #
-#         include ../Makefile.common
+#   * Create a subdirectory <DIR>.
+#   * Write a proof harness (a function) with the name <HARNESS_ENTRY>
+#     in a file with the name <DIR>/<HARNESS_FILE>.c
+#   * Write a makefile with the name <DIR>/Makefile that looks
+#     something like
 #
-#      d. Change directory to <DIR> and run make
+#     HARNESS_FILE=<HARNESS_FILE>
+#     HARNESS_ENTRY=<HARNESS_ENTRY>
+#     PROOF_UID=<PROOF_UID>
 #
-# Dependency handling in this file may not be perfect. Consider
-# running "make clean" or "make veryclean" before "make report" if you
-# get results that are hard to explain.
+#     PROJECT_SOURCES += $(SRCDIR)/libraries/api_1.c
+#     PROJECT_SOURCES += $(SRCDIR)/libraries/api_2.c
+#
+#     PROOF_SOURCES += $(PROOFDIR)/harness.c
+#     PROOF_SOURCES += $(SRCDIR)/cbmc/proofs/stub_a.c
+#     PROOF_SOURCES += $(SRCDIR)/cbmc/proofs/stub_b.c
+#
+#     UNWINDSET += foo.0:3
+#     UNWINDSET += bar.1:6
+#
+#     REMOVE_FUNCTION_BODY += api_stub_a
+#     REMOVE_FUNCTION_BODY += api_stub_b
+#
+#     DEFINES = -DDEBUG=0
+#
+#     include ../Makefile.common
+#
+#   * Change directory to <DIR> and run make
+#
+# The proof setup script cbmc-starter-kit-setup-proof from the CBMC
+# Starter Kit will do most of this for, creating a directory and
+# writing a basic Makefile and proof harness into it that you can edit
+# as described above.
+#
+# Warning: If you get results that are hard to explain, consider
+# running "make clean" or "make veryclean" before "make" if you get
+# results that are hard to explain.  Dependency handling in this
+# Makefile.common may not be perfect.
 
 SHELL=/bin/bash
 

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -304,7 +304,7 @@ COVERFLAGS += $(CBMC_FLAG_MALLOC_FAIL_NULL)
 # (ignoring initializers and default zero-initialization).  The
 # --nondet-static-exclude VAR excludes VAR for the variables
 # initialized with unconstrained values.
-NONDET_STATIC ?= ""
+NONDET_STATIC ?=
 
 # Flags to pass to goto-cc for compilation and linking
 COMPILE_FLAGS ?= -Wall
@@ -528,15 +528,6 @@ $(HARNESS_GOTO)2.goto: $(HARNESS_GOTO)1.goto
 
 # Optionally fill static variable with unconstrained values
 $(HARNESS_GOTO)3.goto: $(HARNESS_GOTO)2.goto
-ifeq ($(NONDET_STATIC),"")
-	$(LITANI) add-job \
-	  --command 'cp $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): not setting static variables to nondet"
-else
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(NONDET_STATIC) $^ $@' \
@@ -547,7 +538,6 @@ else
 	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage build \
 	  --description "$(PROOF_UID): setting static variables to nondet"
-endif
 
 # Omit unused functions (sharpens coverage calculations)
 $(HARNESS_GOTO)4.goto: $(HARNESS_GOTO)3.goto

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -163,14 +163,6 @@ SRCDIR ?= $(abspath ../..)
 # PROOFDIR is the path to the directory containing the proof harness
 PROOFDIR ?= $(abspath .)
 
-# Path to the root of the cbmc project.
-#
-# Projects generally have a directory $(CBMCDIR) with subdirectories
-# $(CBMCDIR)/proofs containing the proofs and maybe $(CBMCDIR)/stubs
-# containing the stubs used in the proof.  This Makefile is generally
-# at $(CBMCDIR)/proofs/Makefile.common.
-CBMCDIR ?= $(PROOF_ROOT)/cbmc
-
 # Default CBMC flags used for property checking and coverage checking.
 CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET) --flush
 

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -389,7 +389,7 @@ CBMC_TIMEOUT ?= 21600
 #    contracts, USE_FUNCTION_CONTRACTS should be a list of function names.
 #    One must check separately whether a function contract is sound before
 #    replacing it in calling contexts.
-CHECK_FUNCTION_CONTRACTS ?= ""
+CHECK_FUNCTION_CONTRACTS ?=
 CBMC_CHECK_FUNCTION_CONTRACTS := $(patsubst %,--enforce-contract %, $(CHECK_FUNCTION_CONTRACTS))
 
 USE_FUNCTION_CONTRACTS ?=
@@ -647,15 +647,6 @@ endif
 
 # Optionally check function contracts
 $(HARNESS_GOTO)9.goto: $(HARNESS_GOTO)8.goto
-ifeq ($(CHECK_FUNCTION_CONTRACTS),"")
-	$(LITANI) add-job \
-	  --command 'cp $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): not checking function contracts"
-else
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_CHECK_FUNCTION_CONTRACTS) $^ $@' \
@@ -666,7 +657,6 @@ else
 	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage build \
 	  --description "$(PROOF_UID): checking function contracts"
-endif
 
 # Final name for proof harness
 $(HARNESS_GOTO).goto: $(HARNESS_GOTO)9.goto

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -96,16 +96,40 @@ default: report
 ################################################################
 ## Section I: This section gives common variable definitions.
 ##
-## Feel free to edit these definitions for your project.
+## Override these definitions in Makefile-project-defines or
+## your proof Makefile.
 ##
-## Definitions specific to a proof (generally definitions defined
-## below with ?= like PROJECT_SOURCES listing the project source files
-## required by the proof) should be defined in the proof Makefile.
-##
-## Remember that this Makefile is intended to be included from the
-## Makefile in your proof directory, so all relative pathnames should
-## be relative to your proof directory.
-##
+## Remember that Makefile.common and Makefile-project-defines are
+## included into the proof Makefile in your proof directory, so all
+## relative pathnames defined there should be relative to your proof
+## directory.
+
+################################################################
+# Define the layout of the source tree and the proof subtree
+#
+# Generally speaking,
+#
+#   SRCDIR = the root of the repository
+#   CBMC_ROOT = /srcdir/cbmc
+#   PROOF_ROOT = /srcdir/cbmc/proofs
+#   PROOF_SOURCE = /srcdir/cbmc/sources
+#   PROOF_INCLUDE = /srcdir/cbmc/include
+#   PROOF_STUB = /srcdir/cbmc/stubs
+#   PROOFDIR = the directory containing the Makefile for your proof
+#
+# The path /srcdir/cbmc used in the example above is determined by the
+# setup script cbmc-starter-kit-setup.  Projects usually create a cbmc
+# directory somewhere in the source tree, and run the setup script in
+# that directory.  The value of CBMC_ROOT becomes the absolute path to
+# that directory.
+#
+# The location of that cbmc directory in the source tree affects the
+# definition of SRCDIR, which is defined in terms of the relative path
+# from a proof directory to the repository root.  The definition is
+# usually determined by the setup script cbmc-starter-kit-setup and
+# written to Makefile-template-defines, but you can override it for a
+# project in Makefile-project-defines and for a specific proof in the
+# Makefile for the proof.
 
 # Absolute path to the directory containing this Makefile.common
 # See https://ftp.gnu.org/old-gnu/Manuals/make-3.80/html_node/make_17.html
@@ -120,17 +144,20 @@ MAKEFILE_PATHS = $(foreach makefile,$(MAKEFILE_LIST),$(abspath $(makefile)))
 PROOF_ROOT = $(dir $(filter %/Makefile.common,$(MAKEFILE_PATHS)))
 
 CBMC_ROOT = $(shell dirname $(PROOF_ROOT))
-PROOF_STUB = $(CBMC_ROOT)/stubs
 PROOF_SOURCE = $(CBMC_ROOT)/sources
+PROOF_INCLUDE = $(CBMC_ROOT)/include
+PROOF_STUB = $(CBMC_ROOT)/stubs
 
 # Project-specific definitions to override default definitions below
 #   * Makefile-project-defines will never be overwritten
-#   * Makefile-template-defines will be overwritten each time the
-#     proof templates are updated
+#   * Makefile-template-defines may be overwritten with the starter
+#     kit is updated
 sinclude $(PROOF_ROOT)/Makefile-project-defines
 sinclude $(PROOF_ROOT)/Makefile-template-defines
 
 # SRCDIR is the path to the root of the source tree
+# This is a default definition that is frequently overridden in
+# another Makefile, see the discussion of SRCDIR above.
 SRCDIR ?= $(abspath ../..)
 
 # PROOFDIR is the path to the directory containing the proof harness
@@ -146,6 +173,9 @@ CBMCDIR ?= $(PROOF_ROOT)/cbmc
 
 # Default CBMC flags used for property checking and coverage checking.
 CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET) --flush
+
+################################################################
+# Define how to run CBMC
 
 # Do property checking with the external SAT solver given by
 # EXTERNAL_SAT_SOLVER.  Do coverage checking with the default solver,
@@ -381,11 +411,6 @@ APPLY_LOOP_CONTRACTS ?= 0
 ifndef VERBOSE
     MAKEFLAGS := $(MAKEFLAGS) -s
 endif
-
-################################################################
-################################################################
-## Section II: This section is for project-specific definitions
-
 
 ################################################################
 ################################################################

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -392,7 +392,7 @@ CBMC_TIMEOUT ?= 21600
 CHECK_FUNCTION_CONTRACTS ?= ""
 CBMC_CHECK_FUNCTION_CONTRACTS := $(patsubst %,--enforce-contract %, $(CHECK_FUNCTION_CONTRACTS))
 
-USE_FUNCTION_CONTRACTS ?= ""
+USE_FUNCTION_CONTRACTS ?=
 CBMC_USE_FUNCTION_CONTRACTS := $(patsubst %,--replace-call-with-contract %, $(USE_FUNCTION_CONTRACTS))
 
 # Similarly, proof writers could also add loop contracts in their source code
@@ -569,15 +569,6 @@ $(HARNESS_GOTO)5.goto: $(HARNESS_GOTO)4.goto
 # This must be done before enforcing function contracts,
 # since contract enforcement inlines all function calls.
 $(HARNESS_GOTO)6.goto: $(HARNESS_GOTO)5.goto
-ifeq ($(USE_FUNCTION_CONTRACTS),"")
-	$(LITANI) add-job \
-	  --command 'cp $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): not replacing function calls with function contracts"
-else
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_USE_FUNCTION_CONTRACTS) $^ $@' \
@@ -588,7 +579,6 @@ else
 	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage build \
 	  --description "$(PROOF_UID): replacing function calls with function contracts"
-endif
 
 # Optionally unwind loops
 #

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -401,6 +401,9 @@ CBMC_USE_FUNCTION_CONTRACTS := $(patsubst %,--replace-call-with-contract %, $(US
 # These contracts are also ignored by default, but may be enabled by setting
 # the APPLY_LOOP_CONTRACTS variable to 1.
 APPLY_LOOP_CONTRACTS ?= 0
+ifeq ($(APPLY_LOOP_CONTRACTS),1)
+  CBMC_APPLY_LOOP_CONTRACTS ?= --apply-loop-contracts
+endif
 
 # Silence makefile output (eg, long litani commands) unless VERBOSE is set.
 ifndef VERBOSE
@@ -624,18 +627,9 @@ endif
 
 # Optionally apply loop contracts
 $(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)7.goto
-ifneq ($(APPLY_LOOP_CONTRACTS),1)
-	$(LITANI) add-job \
-	  --command 'cp $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): not applying loop contracts"
-else
 	$(LITANI) add-job \
 	  --command \
-	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) --apply-loop-contracts $^ $@' \
+	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_APPLY_LOOP_CONTRACTS) $^ $@' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --stdout-file $(LOGDIR)/apply_loop_contracts-log.txt \
@@ -643,7 +637,6 @@ else
 	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage build \
 	  --description "$(PROOF_UID): applying loop contracts"
-endif
 
 # Optionally check function contracts
 $(HARNESS_GOTO)9.goto: $(HARNESS_GOTO)8.goto

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -163,9 +163,6 @@ SRCDIR ?= $(abspath ../..)
 # PROOFDIR is the path to the directory containing the proof harness
 PROOFDIR ?= $(abspath .)
 
-# Default CBMC flags used for property checking and coverage checking.
-CBMCFLAGS += --unwind 1 $(CBMC_UNWINDSET) --flush
-
 ################################################################
 # Define how to run CBMC
 
@@ -255,6 +252,12 @@ CBMC_FLAG_SIGNED_OVERFLOW_CHECK ?= --signed-overflow-check
 CBMC_FLAG_UNDEFINED_SHIFT_CHECK ?= --undefined-shift-check
 CBMC_FLAG_UNSIGNED_OVERFLOW_CHECK ?= --unsigned-overflow-check
 CBMC_FLAG_UNWINDING_ASSERTIONS ?= --unwinding-assertions
+CBMC_FLAG_UNWIND ?= --unwind 1
+CBMC_FLAG_FLUSH ?= --flush
+
+# CBMC flags used for property checking and coverage checking
+
+CBMCFLAGS += $(CBMC_FLAG_UNWIND) $(CBMC_UNWINDSET) $(CBMC_FLAG_FLUSH)
 
 # CBMC flags used for property checking
 

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -490,15 +490,6 @@ $(PROOF_GOTO)1.goto: $(PROOF_SOURCES)
 
 # Optionally remove function bodies from project sources
 $(PROJECT_GOTO)2.goto: $(PROJECT_GOTO)1.goto
-ifeq ($(REMOVE_FUNCTION_BODY),"")
-	$(LITANI) add-job \
-	  --command 'cp $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): not removing function bodies from project sources"
-else
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_REMOVE_FUNCTION_BODY) $^ $@' \
@@ -509,7 +500,6 @@ else
 	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage build \
 	  --description "$(PROOF_UID): removing function bodies from project sources"
-endif
 
 # Link project and proof sources into the proof harness
 $(HARNESS_GOTO)1.goto: $(PROOF_GOTO)1.goto $(PROJECT_GOTO)2.goto

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -515,15 +515,6 @@ $(HARNESS_GOTO)1.goto: $(PROOF_GOTO)1.goto $(PROJECT_GOTO)2.goto
 
 # Optionally restrict function pointers
 $(HARNESS_GOTO)2.goto: $(HARNESS_GOTO)1.goto
-ifeq ($(RESTRICT_FUNCTION_POINTER),"")
-	$(LITANI) add-job \
-	  --command 'cp $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): not restricting function pointers in project sources"
-else
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_RESTRICT_FUNCTION_POINTER) $^ $@' \
@@ -534,7 +525,6 @@ else
 	  --pipeline-name "$(PROOF_UID)" \
 	  --ci-stage build \
 	  --description "$(PROOF_UID): restricting function pointers in project sources"
-endif
 
 # Optionally fill static variable with unconstrained values
 $(HARNESS_GOTO)3.goto: $(HARNESS_GOTO)2.goto

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -46,7 +46,7 @@ CBMC_STARTER_KIT_VERSION = _CBMC_STARTER_KIT_VERSION_
 # read it to understand how the values defined in Section I control
 # things.
 #
-# To use Makefile.common, set variables as describe above as needed,
+# To use Makefile.common, set variables as described above as needed,
 # and then for each proof,
 #
 #   * Create a subdirectory <DIR>.
@@ -150,7 +150,7 @@ PROOF_STUB = $(CBMC_ROOT)/stubs
 
 # Project-specific definitions to override default definitions below
 #   * Makefile-project-defines will never be overwritten
-#   * Makefile-template-defines may be overwritten with the starter
+#   * Makefile-template-defines may be overwritten when the starter
 #     kit is updated
 sinclude $(PROOF_ROOT)/Makefile-project-defines
 sinclude $(PROOF_ROOT)/Makefile-template-defines
@@ -513,7 +513,7 @@ $(PROOF_GOTO)1.goto: $(PROOF_SOURCES)
 	  --ci-stage build \
 	  --description "$(PROOF_UID): building proof binary"
 
-# Optionally remove function bodies from project sources
+# Remove function bodies from project sources
 $(PROJECT_GOTO)2.goto: $(PROJECT_GOTO)1.goto
 	$(LITANI) add-job \
 	  --command \
@@ -538,7 +538,7 @@ $(HARNESS_GOTO)1.goto: $(PROOF_GOTO)1.goto $(PROJECT_GOTO)2.goto
 	  --ci-stage build \
 	  --description "$(PROOF_UID): linking project to proof"
 
-# Optionally restrict function pointers
+# Restrict function pointers
 $(HARNESS_GOTO)2.goto: $(HARNESS_GOTO)1.goto
 	$(LITANI) add-job \
 	  --command \
@@ -551,7 +551,7 @@ $(HARNESS_GOTO)2.goto: $(HARNESS_GOTO)1.goto
 	  --ci-stage build \
 	  --description "$(PROOF_UID): restricting function pointers in project sources"
 
-# Optionally fill static variable with unconstrained values
+# Fill static variable with unconstrained values
 $(HARNESS_GOTO)3.goto: $(HARNESS_GOTO)2.goto
 	$(LITANI) add-job \
 	  --command \
@@ -590,7 +590,7 @@ $(HARNESS_GOTO)5.goto: $(HARNESS_GOTO)4.goto
 	  --ci-stage build \
 	  --description "$(PROOF_UID): slicing global initializations"
 
-# Optionally replace function calls with function contracts
+# Replace function calls with function contracts
 # This must be done before enforcing function contracts,
 # since contract enforcement inlines all function calls.
 $(HARNESS_GOTO)6.goto: $(HARNESS_GOTO)5.goto
@@ -605,7 +605,7 @@ $(HARNESS_GOTO)6.goto: $(HARNESS_GOTO)5.goto
 	  --ci-stage build \
 	  --description "$(PROOF_UID): replacing function calls with function contracts"
 
-# Optionally unwind loops for loop and function contracts
+# Unwind loops for loop and function contracts
 $(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
 	$(LITANI) add-job \
 	  --command \
@@ -618,7 +618,7 @@ $(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
 	  --ci-stage build \
 	  --description "$(PROOF_UID): unwinding loops"
 
-# Optionally apply loop contracts
+# Apply loop contracts
 $(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)7.goto
 	$(LITANI) add-job \
 	  --command \
@@ -631,7 +631,7 @@ $(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)7.goto
 	  --ci-stage build \
 	  --description "$(PROOF_UID): applying loop contracts"
 
-# Optionally check function contracts
+# Check function contracts
 $(HARNESS_GOTO)9.goto: $(HARNESS_GOTO)8.goto
 	$(LITANI) add-job \
 	  --command \

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -583,50 +583,8 @@ $(HARNESS_GOTO)6.goto: $(HARNESS_GOTO)5.goto
 	  --ci-stage build \
 	  --description "$(PROOF_UID): replacing function calls with function contracts"
 
-# Optionally unwind loops
-#
-# Loop unwinding must be done before enforcing function contracts, because
-# loop unwinding does not replicate writeset snapshots that might be
-# introduced during contract enforcement.
-#
-# CBMC has its own model of standard library functions like strcmp.  These
-# functions do not appear in the goto program, they are added to the goto
-# program by CBMC itself.  For this reason, we will need to pass these loop
-# unwinding instructions again to the invocation of CBMC to unwind any loops
-# remaining in functions like strcmp.  We could pull these functions into the
-# goto program with `goto-instrument --add-library`, but enforcing function
-# contracts currently assumes they are missing.
-#
-# The meaning of `--unwindset LOOP:N` depends on the program invoked.  The
-# program goto-instrument will unwind the loop N times.  The program cbmc will
-# unwind the loop N-1 times.  Unwinding with goto-instrument instead of cbmc
-# is obviously sound, but may lead to performance issues if the loops is big
-# and the difference between unwinding N-1 and N is big.
-#
-$(HARNESS_GOTO)7.goto: $(HARNESS_GOTO)6.goto
-ifeq ($(UNWINDSET),"")
-	$(LITANI) add-job \
-	  --command 'cp $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): not unwinding loops"
-else
-	$(LITANI) add-job \
-	  --command \
-	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_UNWINDSET) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $^ $@' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --stdout-file $(LOGDIR)/unwind_loops-log.txt \
-	  --interleave-stdout-stderr \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage build \
-	  --description "$(PROOF_UID): unwinding loops"
-endif
-
 # Optionally apply loop contracts
-$(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)7.goto
+$(HARNESS_GOTO)8.goto: $(HARNESS_GOTO)6.goto
 	$(LITANI) add-job \
 	  --command \
 	    '$(GOTO_INSTRUMENT) $(CBMC_VERBOSITY) $(CBMC_APPLY_LOOP_CONTRACTS) $^ $@' \
@@ -668,7 +626,7 @@ $(LOGDIR)/result.txt: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
 	  $(POOL) \
 	  --command \
-	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CHECKFLAGS) --trace $<' \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --trace $<' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --ci-stage test \
@@ -685,7 +643,7 @@ $(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
 	  $(POOL) \
 	  --command \
-	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CHECKFLAGS) --trace --xml-ui $<' \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --trace --xml-ui $<' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --ci-stage test \
@@ -701,7 +659,7 @@ $(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
 $(LOGDIR)/property.xml: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
 	  --command \
-	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CHECKFLAGS) --show-properties --xml-ui $<' \
+	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --show-properties --xml-ui $<' \
 	  --inputs $^ \
 	  --outputs $@ \
 	  --ci-stage test \

--- a/src/cbmc_starter_kit/update.py
+++ b/src/cbmc_starter_kit/update.py
@@ -8,6 +8,7 @@
 from pathlib import Path
 import logging
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -141,20 +142,20 @@ def remove_submodule(cbmc_root, submodule_name, submodule_path):
 def update_litani_makefile_variable(cbmc_root, path):
     """Update LITANI to LITANI?=litani in the makefile at the named path"""
 
+    is_litani_line = lambda line: bool(re.match(r'^\s*LITANI\s*\??=', line))
+
     with open(cbmc_root/path, encoding='utf-8') as makefile:
         lines = makefile.read().splitlines()
-    litani_prefix = 'LITANI ?='
-    if not any(line.strip().startswith(litani_prefix) for line in lines):
+    if not any(is_litani_line(line) for line in lines):
         logging.debug("Not updating LITANI in makefile: %s", path)
         return
 
-    litani_define = f'{litani_prefix} litani' # litani_define == 'LITANI ?= litani'
-    logging.info("Updating '%s' in makefile: %s", litani_define, path)
+    logging.info("Updating LITANI in makefile: %s", path)
     with open(cbmc_root/path, 'w', encoding='utf-8') as makefile:
         for line in lines:
-            if line.strip().startswith(litani_prefix):
-                line = litani_define
-            makefile.write(f"{line}\n")
+            if is_litani_line(line):
+                line = 'LITANI ?= litani'
+            print(line, file=makefile)
     return
 
 ################################################################

--- a/src/cbmc_starter_kit/version.py
+++ b/src/cbmc_starter_kit/version.py
@@ -4,7 +4,7 @@
 """Version number."""
 
 NAME = "CBMC starter kit"
-NUMBER = "2.1.1"
+NUMBER = "2.2"
 VERSION = f"{NAME} {NUMBER}"
 
 REPLACE_TARGET = '_CBMC_STARTER_KIT_VERSION_'


### PR DESCRIPTION
This pull request removes conditional invocations of goto-instrument.  The command goto-instrument is idempotent when called with no flags (it just copies the file), so checking whether a flag is set before calling goto-instrument is unnecessary and complicates the makefile.common.  

This pull request also modifies when loop unwinding is done.  It moves all loop unwinding of loops specified by UNWINDSET back to the invocations of cbmc (no more early invocation of goto-instrument to do it), but it does introduce a new EARLY_UNWINDSET to support selective loop unwinding for the purpose of function and loop contract checking.

This pull request also cleans up some comments in makefile.common and advances the release to 2.2.

These changes have been checked against all starter kit proofs in github.  The differences found were
* removal of most (but not all) of the 'unknown loop identifier' warnings that resulted from giving loop unwinding instructions to both goto-instrument and cbmc
* removal of a 'conflicting initializers' warning in derive_data_key
* off-by-one differences in coverage reports due to the fact that a `do` statement is no longer considered by cbmc to be contributing goto instructions
* many instances of a line considered "both" hit and missed are now considered just "hit" (unrolling causes a single line of code to contribute to many basic blocks, some unreachable if the loop is unwound an extra iteration by goto-instrument)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
