### PR TITLE
Update tutorial documentation

### DIFF
--- a/docs/src/tutorial/README.md
+++ b/docs/src/tutorial/README.md
@@ -29,7 +29,7 @@ Using the starter kit consists of five steps
 * [Configure the repository](#configure-the-repository)
 * [Configure the proof](#configure-the-proof)
 * [Write the proof](#write-the-proof)
-* [Run CBMC](#run-cbmc)
+* [Run the proof](#run-the-proof)
 
 ## Clone the source repository
 

--- a/docs/src/tutorial/README.md
+++ b/docs/src/tutorial/README.md
@@ -292,7 +292,7 @@ This builds a report of the results that we can open in a browser
 ```
 open report/html/index.html
 ```
-Examining [the report](report/index.html), we see a list of coverage results, a list of
+Examining [the report](report/html/index.html), we see a list of coverage results, a list of
 warnings, and a list of errors or issues found by CBMC.  In this report,
 there are no errors, but the coverage is *terrible*: only 40% of the lines
 in the function are exercised by CBMC!

--- a/docs/src/tutorial/report/html/index.html
+++ b/docs/src/tutorial/report/html/index.html
@@ -1,0 +1,113 @@
+
+
+<html>
+    <head>
+      <title>CBMC</title>
+      <link rel="stylesheet" type="text/css" href="/viewer.css">
+    </head>
+  
+    <body>
+      <h1>CBMC report</h1>
+  
+      <div class="coverage">
+        <h2>Coverage</h2>
+        
+  
+        
+        
+        <p>
+          Coverage: 0.31 (reached 35 of 114 reachable lines)
+        </p>
+        
+  
+        
+        
+        <table class="coverage">
+          <tr>
+            <th class="coverage">Coverage</th>
+            <th class="function">Function</th>
+            <th class="file">File</th>
+          </tr>
+          
+          <tr>
+            <td class="coverage">0.81 (29/36)</td>
+            <td class="function"><a href="./portable/MemMang/heap_5.c.html#442">vPortDefineHeapRegions</a></td>
+            <td class="file"><a href="./portable/MemMang/heap_5.c.html">portable/MemMang/heap_5.c</a></td>
+          </tr>
+          
+          <tr>
+            <td class="coverage">0.43 (6/14)</td>
+            <td class="function"><a href="./cbmc/proofs/pvPortMalloc/pvPortMalloc_harness.c.html#10">harness</a></td>
+            <td class="file"><a href="./cbmc/proofs/pvPortMalloc/pvPortMalloc_harness.c.html">cbmc/proofs/pvPortMalloc/pvPortMalloc_harness.c</a></td>
+          </tr>
+          
+          <tr>
+            <td class="coverage">0.00 (0/17)</td>
+            <td class="function"><a href="./portable/MemMang/heap_5.c.html#379">prvInsertBlockIntoFreeList</a></td>
+            <td class="file"><a href="./portable/MemMang/heap_5.c.html">portable/MemMang/heap_5.c</a></td>
+          </tr>
+          
+          <tr>
+            <td class="coverage">0.00 (0/33)</td>
+            <td class="function"><a href="./portable/MemMang/heap_5.c.html#155">pvPortMalloc</a></td>
+            <td class="file"><a href="./portable/MemMang/heap_5.c.html">portable/MemMang/heap_5.c</a></td>
+          </tr>
+          
+          <tr>
+            <td class="coverage">0.00 (0/14)</td>
+            <td class="function"><a href="./portable/MemMang/heap_5.c.html#295">vPortFree</a></td>
+            <td class="file"><a href="./portable/MemMang/heap_5.c.html">portable/MemMang/heap_5.c</a></td>
+          </tr>
+          
+        </table>
+      </div>
+      
+  
+      
+  
+      <div class="warnings">
+        <h2> Warnings</h2>
+        
+  
+        
+  
+        
+  
+        
+  
+        
+        None
+        
+  
+      <div class="errors">
+        <h2>Errors</h2>
+        
+  
+        
+        <ul>
+          <li>Loop unwinding failures
+            <ul>
+              
+              <li> [<a href="./traces/vPortDefineHeapRegions.unwind.0.html">trace</a>]
+                vPortDefineHeapRegions.unwind.0
+                in line
+                <a href="./portable/MemMang/heap_5.c.html#456">456</a>
+                in file
+                <a href="./portable/MemMang/heap_5.c.html">portable/MemMang/heap_5.c</a>
+              </li>
+              
+            </ul>
+          </li>
+        </ul>
+        
+  
+        
+  
+        
+  
+        
+  
+      </div>
+    </body>
+  </html>
+  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


- Renamed the 5th step in the tutorial to the pvPortMalloc tutorial from "Run CBMC" to "Run the proof". This heading is what was being used in the section itself.
- Added a CBMC viewer HTML artifact for the pvPortMalloc proof that reflects the comment in the tutorial concerning an initially terrible 40% line coverage by CBMC.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
