### PR TITLE
Remove .litani_cache_dir from individual directory before considering proof

### DIFF
--- a/src/cbmc_starter_kit/template-for-repository/proofs/run-cbmc-proofs.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/run-cbmc-proofs.py
@@ -180,13 +180,13 @@ def get_proof_dirs(proof_root, proof_list, marker_file):
 
     for root, _, fyles in os.walk(proof_root):
         proof_name = str(pathlib.Path(root).name)
+        if root != str(proof_root) and ".litani_cache_dir" in fyles:
+            pathlib.Path(f"{root}/.litani_cache_dir").unlink()
         if proof_list and proof_name not in proof_list:
             continue
         if proof_list and proof_name in proofs_remaining:
             proofs_remaining.remove(proof_name)
         if marker_file in fyles:
-            if ".litani_cache_dir" in fyles:
-                pathlib.Path(f"{proof_name}/.litani_cache_dir").unlink()
             yield root
 
     if proofs_remaining:

--- a/src/cbmc_starter_kit/template-for-repository/proofs/run-cbmc-proofs.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/run-cbmc-proofs.py
@@ -185,6 +185,8 @@ def get_proof_dirs(proof_root, proof_list, marker_file):
         if proof_list and proof_name in proofs_remaining:
             proofs_remaining.remove(proof_name)
         if marker_file in fyles:
+            if ".litani_cache_dir" in fyles:
+                pathlib.Path(f"{proof_name}/.litani_cache_dir").unlink()
             yield root
 
     if proofs_remaining:


### PR DESCRIPTION
*Issue #, if available:*

#116 

*Description of changes:*

If `make report` is executed within an individual CBMC proof directory, Litani
will create its "cache pointer" (a file called .litani_cache_dir).

This change makes sure that such a file is deleted prior to that individual CBMC
proof directory being included in the list of all proof directories.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
