### PR TITLE
Add test for CBMC starter kit and update subprocess command that runs individual proofs

### DIFF
--- a/.github/workflows/makefile-test.yaml
+++ b/.github/workflows/makefile-test.yaml
@@ -1,0 +1,29 @@
+name: Test CBMC starter-kit by using coreHTTP
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  push:
+    branches: [ master ]
+
+jobs:
+  run-tests:
+    if: "!contains(github.event.pull_request.labels.*.name, 'no-test')"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.8', '3.9', '3.10' ]
+    name: Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          brew install scdoc mandoc coreutils ninja cbmc aws/tap/cbmc-viewer
+          python3 -m pip install pyyaml jinja2
+      - name: Run test target in Makefile
+        run: |
+          cd test/repo
+          make test

--- a/src/cbmc_starter_kit/template-for-repository/proofs/run-cbmc-proofs.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/run-cbmc-proofs.py
@@ -295,7 +295,7 @@ async def configure_proof_dirs(
 
         # Allow interactive tasks to preempt proof configuration
         proc = await asyncio.create_subprocess_exec(
-            "nice", "-n", "15", "make", "VERBOSE=1" if debug else "", *pools,
+            "nice", "-n", "15", "make", *pools,
             *profiling, "-B", "_report", "" if debug else "--quiet", cwd=path,
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
         stdout, stderr = await proc.communicate()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

As I was testing my changes that are part of #121 , I noticed that the single cbmc-starter-kit test (i.e. the "test Makefile") had been broken.

This PR:

- introduces a GitHub Actions test workflow
- updates the `make _report` sub-process command to not include `VERBOSE=1`. This was causing the "test Makefie" to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
