### PR TITLE
Print summary table even when some proofs fail

### DIFF
--- a/src/cbmc_starter_kit/template-for-repository/proofs/run-cbmc-proofs.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/run-cbmc-proofs.py
@@ -219,10 +219,8 @@ def run_build(litani, jobs, fail_on_proof_failure, summarize):
 
     logging.debug(" ".join(cmd))
     proc = subprocess.run(cmd, check=False)
-    if proc.returncode:
-        if fail_on_proof_failure:
-            logging.error("One or more proofs failed")
-            sys.exit(10)
+
+    if proc.returncode and not fail_on_proof_failure:
         logging.critical("Failed to run litani run-build")
         sys.exit(1)
 
@@ -230,6 +228,9 @@ def run_build(litani, jobs, fail_on_proof_failure, summarize):
         print_proof_results(out_file)
         out_file.unlink()
 
+    if proc.returncode:
+        logging.error("One or more proofs failed")
+        sys.exit(10)
 
 def get_litani_path(proof_root):
     cmd = [


### PR DESCRIPTION
Prior to this commit, passing --fail-on-pipeline-failure would terminate
run-cbmc-proofs.py without printing the summary table if some of the
proofs failed. This commit fixes that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
