### PR TITLE
Better type + doxygen comment for harness

### DIFF
--- a/src/cbmc_starter_kit/template-for-proof/FUNCTION_harness.c
+++ b/src/cbmc_starter_kit/template-for-proof/FUNCTION_harness.c
@@ -16,7 +16,11 @@
  *   - include the types needed to declare function arguments
  */
 
-void harness()
+/**
+ * @brief Starting point for formal analysis
+ * 
+ */
+void harness(void)
 {
 
   /* Insert argument declarations */


### PR DESCRIPTION
I wanted a more precise type for the "harness" function as a better example for users to follow. 

Also added a doxygen comment for the harness function as an example for users to follow.