### PR TITLE
Fix typo in epilog of cbmc-starter-kit-migrate-license command

### DIFF
--- a/src/cbmc_starter_kit/migrate_license.py
+++ b/src/cbmc_starter_kit/migrate_license.py
@@ -120,7 +120,7 @@ def main():
     The CBMC starter kit was originally released under the Apache
     license. All files in the starter kit contained references to the
     Apache license. The starter kit installation scripts copied files
-    from the stater kit into the project repository.  This became an
+    from the starter kit into the project repository.  This became an
     issue when the project repository was released under a different
     license.  This script removes all references to the Apache license
     from the files copied into the project repository from the starter


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
