### PR TITLE
Remove macOS 10.15 in GitHub Actions "build-bottle" job

### DIFF
--- a/.github/workflows/release-brew.yaml
+++ b/.github/workflows/release-brew.yaml
@@ -74,7 +74,7 @@ jobs:
     needs: homebrew-pr
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

GitHub is planning to deprecate macOS 10.15 GitHub actions next month and is failing certain CI builds to raise awareness ([link](https://github.com/actions/virtual-environments/issues/5583))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
