### PR TITLE
Remove support for cbmc-viewer 1.0

### DIFF
--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -943,38 +943,6 @@ veryclean: clean
 
 ################################################################
 
-# Rule for generating cbmc-batch.yaml, used by the CI at
-# https://github.com/awslabs/aws-batch-cbmc/
-
-JOB_OS ?= ubuntu16
-JOB_MEMORY ?= 32000
-
-# Proofs that are expected to fail should set EXPECTED to
-# "FAILED" in their Makefile. Values other than SUCCESSFUL
-# or FAILED will cause a CI error.
-EXPECTED ?= SUCCESSFUL
-
-define yaml_encode_options
-	"$(shell echo $(1) | sed 's/ ,/ /g' | sed 's/ /;/g')"
-endef
-
-CI_FLAGS = $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) $(COVERFLAGS)
-
-cbmc-batch.yaml:
-	@$(RM) $@
-	@echo 'build_memory: $(JOB_MEMORY)' > $@
-	@echo 'cbmcflags: $(strip $(call yaml_encode_options,$(CI_FLAGS)))' >> $@
-	@echo 'coverage_memory: $(JOB_MEMORY)' >> $@
-	@echo 'expected: $(EXPECTED)' >> $@
-	@echo 'goto: $(HARNESS_GOTO).goto' >> $@
-	@echo 'jobos: $(JOB_OS)' >> $@
-	@echo 'property_memory: $(JOB_MEMORY)' >> $@
-	@echo 'report_memory: $(JOB_MEMORY)' >> $@
-
-.PHONY: cbmc-batch.yaml
-
-################################################################
-
 # Run "make echo-proof-uid" to print the proof ID of a proof. This can be
 # used by scripts to ensure that every proof has an ID, that there are
 # no duplicates, etc.

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -770,11 +770,13 @@ $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
 	  --stderr-file $(LOGDIR)/coverage-err-log.txt \
 	  --description "$(PROOF_UID): calculating coverage"
 
+VIEWER_COVERAGE_FLAG ?= --coverage $(LOGDIR)/coverage.xml
+
 $(PROOFDIR)/report: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
 	$(LITANI) add-job \
 	  --command " $(VIEWER) \
 	    --result $(LOGDIR)/result.xml \
-	    --coverage $(LOGDIR)/coverage.xml \
+	    $(VIEWER_COVERAGE_FLAG) \
 	    --property $(LOGDIR)/property.xml \
 	    --srcdir $(SRCDIR) \
 	    --goto $(HARNESS_GOTO).goto \
@@ -786,22 +788,6 @@ $(PROOFDIR)/report: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/covera
 	  --stdout-file $(LOGDIR)/viewer-log.txt \
 	  --ci-stage report \
 	  --description "$(PROOF_UID): generating report"
-
-$(PROOFDIR)/report-no-coverage: $(LOGDIR)/result.xml $(LOGDIR)/property.xml
-	$(LITANI) add-job \
-	  --command " $(VIEWER) \
-	    --result $(LOGDIR)/result.xml \
-	    --property $(LOGDIR)/property.xml \
-	    --srcdir $(SRCDIR) \
-	    --goto $(HARNESS_GOTO).goto \
-	    --reportdir $(PROOFDIR)/report-no-coverage \
-	    --config $(PROOFDIR)/cbmc-viewer.json" \
-	  --inputs $^ \
-	  --outputs $(PROOFDIR)/report-no-coverage \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --stdout-file $(LOGDIR)/viewer-log.txt \
-	  --ci-stage report \
-	  --description "$(PROOF_UID): generating report (no coverage)"
 
 litani-path:
 	@echo $(LITANI)
@@ -860,14 +846,10 @@ report:
 	@ echo Running 'litani build'
 	$(LITANI) run-build
 
-_report_no_coverage: $(PROOFDIR)/report-no-coverage
+_report_no_coverage:
+	$(MAKE) VIEWER_COVERAGE_FLAG = "" _report
 report-no-coverage:
-	@ echo Running 'litani init'
-	$(LITANI) init --project $(PROJECT_NAME)
-	@ echo Running 'litani add-job'
-	$(MAKE) -B _report_no_coverage
-	@ echo Running 'litani build'
-	$(LITANI) run-build
+	$(MAKE) VIEWER_COVERAGE_FLAG = "" report
 
 ################################################################
 # Targets to clean up after ourselves
@@ -878,7 +860,7 @@ clean:
 	-$(RM) $(REWRITTEN_SOURCES) $(foreach rs,$(REWRITTEN_SOURCES),$(rs).json)
 
 veryclean: clean
-	-$(RM) -r report report-no-coverage
+	-$(RM) -r report
 	-$(RM) -r $(LOGDIR) $(GOTODIR)
 
 .PHONY: \
@@ -886,12 +868,14 @@ veryclean: clean
   _goto \
   _property \
   _report \
+  _report_no_coverage \
   clean \
   coverage \
   goto \
   litani-path \
   property \
   report \
+  report-no-coverage \
   result \
   setup_dependencies \
   testdeps \

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -770,9 +770,10 @@ $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
 	  --stderr-file $(LOGDIR)/coverage-err-log.txt \
 	  --description "$(PROOF_UID): calculating coverage"
 
-VIEWER_COVERAGE_FLAG ?= --coverage $(LOGDIR)/coverage.xml
+COVERAGE ?= $(LOGDIR)/coverage.xml
+VIEWER_COVERAGE_FLAG ?= --coverage $(COVERAGE)
 
-$(PROOFDIR)/report: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
+$(PROOFDIR)/report: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(COVERAGE)
 	$(LITANI) add-job \
 	  --command " $(VIEWER) \
 	    --result $(LOGDIR)/result.xml \
@@ -847,9 +848,9 @@ report:
 	$(LITANI) run-build
 
 _report_no_coverage:
-	$(MAKE) VIEWER_COVERAGE_FLAG = "" _report
+	$(MAKE) COVERAGE="" VIEWER_COVERAGE_FLAG="" _report
 report-no-coverage:
-	$(MAKE) VIEWER_COVERAGE_FLAG = "" report
+	$(MAKE) COVERAGE="" VIEWER_COVERAGE_FLAG=" " report
 
 ################################################################
 # Targets to clean up after ourselves

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -787,6 +787,22 @@ $(PROOFDIR)/report: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/covera
 	  --ci-stage report \
 	  --description "$(PROOF_UID): generating report"
 
+$(PROOFDIR)/report-no-coverage: $(LOGDIR)/result.xml $(LOGDIR)/property.xml
+	$(LITANI) add-job \
+	  --command " $(VIEWER) \
+	    --result $(LOGDIR)/result.xml \
+	    --property $(LOGDIR)/property.xml \
+	    --srcdir $(SRCDIR) \
+	    --goto $(HARNESS_GOTO).goto \
+	    --reportdir $(PROOFDIR)/report-no-coverage \
+	    --config $(PROOFDIR)/cbmc-viewer.json" \
+	  --inputs $^ \
+	  --outputs $(PROOFDIR)/report-no-coverage \
+	  --pipeline-name "$(PROOF_UID)" \
+	  --stdout-file $(LOGDIR)/viewer-log.txt \
+	  --ci-stage report \
+	  --description "$(PROOF_UID): generating report (no coverage)"
+
 litani-path:
 	@echo $(LITANI)
 
@@ -844,6 +860,15 @@ report:
 	@ echo Running 'litani build'
 	$(LITANI) run-build
 
+_report_no_coverage: $(PROOFDIR)/report-no-coverage
+report-no-coverage:
+	@ echo Running 'litani init'
+	$(LITANI) init --project $(PROJECT_NAME)
+	@ echo Running 'litani add-job'
+	$(MAKE) -B _report_no_coverage
+	@ echo Running 'litani build'
+	$(LITANI) run-build
+
 ################################################################
 # Targets to clean up after ourselves
 clean:
@@ -853,7 +878,7 @@ clean:
 	-$(RM) $(REWRITTEN_SOURCES) $(foreach rs,$(REWRITTEN_SOURCES),$(rs).json)
 
 veryclean: clean
-	-$(RM) -r report
+	-$(RM) -r report report-no-coverage
 	-$(RM) -r $(LOGDIR) $(GOTODIR)
 
 .PHONY: \

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -441,7 +441,6 @@ GOTO_CC ?= goto-cc
 GOTO_INSTRUMENT ?= goto-instrument
 CRANGLER ?= crangler
 VIEWER ?= cbmc-viewer
-MAKE_SOURCE ?= make-source
 VIEWER2 ?= cbmc-viewer
 CMAKE ?= cmake
 
@@ -810,14 +809,6 @@ $(PROOFDIR)/html: $(LOGDIR)/result.txt $(LOGDIR)/property.xml $(LOGDIR)/coverage
 	  --description "$(PROOF_UID): generating report"
 
 
-# Caution: run make-source before running property and coverage checking
-# The current make-source script removes the goto binary
-$(LOGDIR)/source.json:
-	mkdir -p $(dir $@)
-	$(RM) -r $(GOTODIR)
-	$(MAKE_SOURCE) --srcdir $(SRCDIR) --wkdir $(PROOFDIR) > $@
-	$(RM) -r $(GOTODIR)
-
 define VIEWER2_CMD
   $(VIEWER2) \
     --result $(LOGDIR)/result.xml \
@@ -830,9 +821,6 @@ define VIEWER2_CMD
 endef
 export VIEWER2_CMD
 
-# Omit logs/source.json from report generation until make-sources
-# works correctly with Makefiles that invoke the compiler with
-# mutliple source files at once.
 $(PROOFDIR)/report: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
 	$(LITANI) add-job \
 	  --command "$$VIEWER2_CMD" \

--- a/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/Makefile.common
@@ -723,23 +723,6 @@ $(HARNESS_GOTO).goto: $(HARNESS_GOTO)9.goto
 ################################################################
 # Targets to run the analysis commands
 
-$(LOGDIR)/result.txt: $(HARNESS_GOTO).goto
-	$(LITANI) add-job \
-	  $(POOL) \
-	  --command \
-	    '$(CBMC) $(CBMC_VERBOSITY) $(CBMCFLAGS) $(CBMC_FLAG_UNWINDING_ASSERTIONS) $(CHECKFLAGS) --trace $<' \
-	  --inputs $^ \
-	  --outputs $@ \
-	  --ci-stage test \
-	  --stdout-file $@ \
-	  $(MEMORY_PROFILING) \
-	  --ignore-returns 10 \
-	  --timeout $(CBMC_TIMEOUT) \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --tags "stats-group:safety checks" \
-	  --stderr-file $(LOGDIR)/result-err-log.txt \
-	  --description "$(PROOF_UID): checking safety properties"
-
 $(LOGDIR)/result.xml: $(HARNESS_GOTO).goto
 	$(LITANI) add-job \
 	  $(POOL) \
@@ -787,43 +770,16 @@ $(LOGDIR)/coverage.xml: $(HARNESS_GOTO).goto
 	  --stderr-file $(LOGDIR)/coverage-err-log.txt \
 	  --description "$(PROOF_UID): calculating coverage"
 
-define VIEWER_CMD
-  $(VIEWER) \
-    --result $(LOGDIR)/result.txt \
-    --block $(LOGDIR)/coverage.xml \
-    --property $(LOGDIR)/property.xml \
-    --srcdir $(SRCDIR) \
-    --goto $(HARNESS_GOTO).goto \
-    --htmldir $(PROOFDIR)/html
-endef
-export VIEWER_CMD
-
-$(PROOFDIR)/html: $(LOGDIR)/result.txt $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
-	$(LITANI) add-job \
-	  --command "$$VIEWER_CMD" \
-	  --inputs $^ \
-	  --outputs $(PROOFDIR)/html \
-	  --pipeline-name "$(PROOF_UID)" \
-	  --ci-stage report \
-	  --stdout-file $(LOGDIR)/viewer-log.txt \
-	  --description "$(PROOF_UID): generating report"
-
-
-define VIEWER2_CMD
-  $(VIEWER2) \
-    --result $(LOGDIR)/result.xml \
-    --coverage $(LOGDIR)/coverage.xml \
-    --property $(LOGDIR)/property.xml \
-    --srcdir $(SRCDIR) \
-    --goto $(HARNESS_GOTO).goto \
-    --reportdir $(PROOFDIR)/report \
-    --config $(PROOFDIR)/cbmc-viewer.json
-endef
-export VIEWER2_CMD
-
 $(PROOFDIR)/report: $(LOGDIR)/result.xml $(LOGDIR)/property.xml $(LOGDIR)/coverage.xml
 	$(LITANI) add-job \
-	  --command "$$VIEWER2_CMD" \
+	  --command " $(VIEWER) \
+	    --result $(LOGDIR)/result.xml \
+	    --coverage $(LOGDIR)/coverage.xml \
+	    --property $(LOGDIR)/property.xml \
+	    --srcdir $(SRCDIR) \
+	    --goto $(HARNESS_GOTO).goto \
+	    --reportdir $(PROOFDIR)/report \
+	    --config $(PROOFDIR)/cbmc-viewer.json" \
 	  --inputs $^ \
 	  --outputs $(PROOFDIR)/report \
 	  --pipeline-name "$(PROOF_UID)" \
@@ -879,17 +835,8 @@ coverage:
 	@ echo Running 'litani build'
 	$(LITANI) run-build
 
-# Choose the invocation of cbmc-viewer depending on which version of
-# cbmc-viewer is installed.  The --version flag is not implemented in
-# version 1 --- it is an "unrecognized argument" --- but it is
-# implemented in version 2.
-_report1: $(PROOFDIR)/html
-_report2: $(PROOFDIR)/report
-_report:
-	(cbmc-viewer --version 2>&1 | grep "unrecognized argument" > /dev/null) && \
-		$(MAKE) -B _report1 || $(MAKE) -B _report2
-
-report report1 report2:
+_report: $(PROOFDIR)/report
+report:
 	@ echo Running 'litani init'
 	$(LITANI) init --project $(PROJECT_NAME)
 	@ echo Running 'litani add-job'
@@ -906,7 +853,7 @@ clean:
 	-$(RM) $(REWRITTEN_SOURCES) $(foreach rs,$(REWRITTEN_SOURCES),$(rs).json)
 
 veryclean: clean
-	-$(RM) -r html report
+	-$(RM) -r report
 	-$(RM) -r $(LOGDIR) $(GOTODIR)
 
 .PHONY: \
@@ -914,15 +861,12 @@ veryclean: clean
   _goto \
   _property \
   _report \
-  _report2 \
-  _result \
   clean \
   coverage \
   goto \
   litani-path \
   property \
   report \
-  report2 \
   result \
   setup_dependencies \
   testdeps \

--- a/src/cbmc_starter_kit/template-for-repository/proofs/README.md
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/README.md
@@ -9,12 +9,16 @@ This directory includes four Makefiles.
 One Makefile describes the basic workflow for building and running proofs:
 
 * Makefile.common:
-    * make: builds the goto binary, does the cbmc property checking
-	  and coverage checking, and builds the final report.
-	* make goto: builds the goto binary
-	* make result: does cbmc property checking
-	* make coverage: does cbmc coverage checking
-	* make report: builds the final report
+  * make goto: builds the goto binary
+  * make result: does cbmc property checking
+  * make coverage: does cbmc coverage checking
+  * make report: builds the final report
+
+Running `make` or `make report` builds the final report.  Running
+`make report-no-coverage` builds the final report but without checking
+coverage.  Coverage checking can be slow, and it is usually not
+interesting until after the issues raised by property checking have
+been resolved.
 
 Three included Makefiles describe project-specific settings and can override
 definitions in Makefile.common:

--- a/src/cbmc_starter_kit/template-for-repository/proofs/run-cbmc-proofs.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/run-cbmc-proofs.py
@@ -155,6 +155,10 @@ def get_args():
             "action": "version",
             "version": "_CBMC_STARTER_KIT_VERSION_",
             "help": "display version and exit"
+    }, {
+            "flags": ["--no-coverage"],
+            "action": "store_true",
+            "help": "do property checking without coverage checking"
     }]:
         flags = arg.pop("flags")
         pars.add_argument(*flags, **arg)
@@ -297,7 +301,7 @@ def should_enable_pools(litani_caps, args):
 
 
 async def configure_proof_dirs( # pylint: disable=too-many-arguments
-    queue, counter, proof_uids, enable_pools, enable_memory_profiling, debug):
+        queue, counter, proof_uids, enable_pools, enable_memory_profiling, report_target, debug):
     while True:
         print_counter(counter)
         path = str(await queue.get())
@@ -311,7 +315,7 @@ async def configure_proof_dirs( # pylint: disable=too-many-arguments
         # Allow interactive tasks to preempt proof configuration
         proc = await asyncio.create_subprocess_exec(
             "nice", "-n", "15", "make", *pools,
-            *profiling, "-B", "_report", "" if debug else "--quiet", cwd=path,
+            *profiling, "-B", report_target, "" if debug else "--quiet", cwd=path,
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
         stdout, stderr = await proc.communicate()
         logging.debug("returncode: %s", str(proc.returncode))
@@ -388,11 +392,12 @@ async def main(): # pylint: disable=too-many-locals
     tasks = []
 
     enable_memory_profiling = should_enable_memory_profiling(litani_caps, args)
+    report_target = "_report_no_coverage" if args.no_coverage else "_report"
 
     for _ in range(task_pool_size()):
         task = asyncio.create_task(configure_proof_dirs(
             proof_queue, counter, proof_uids, enable_pools,
-            enable_memory_profiling, args.debug))
+            enable_memory_profiling, report_target, args.debug))
         tasks.append(task)
 
     await proof_queue.join()


### PR DESCRIPTION
This pull request removes support of deprecated tools (cbmc-batch, cbmc-viewer version 1, and make-source) and adds support for generating reports without coverage: Running "make report" generates a report with property and coverage checking in "report" subdirectory, and running "make report-no-coverage" generates a report with only property checking in "report-no-coverage".