### PR TITLE
Advance starter kit version 2.6 -> 2.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 
 [metadata]
 name = cbmc-starter-kit
-version = 2.6
+version = 2.7
 author = Mark R. Tuttle
 author_email = mrtuttle@amazon.com
 description = CBMC starter kit makes it easy to add CBMC verification to a software project

--- a/src/cbmc_starter_kit/version.py
+++ b/src/cbmc_starter_kit/version.py
@@ -4,7 +4,7 @@
 """Version number."""
 
 NAME = "CBMC starter kit"
-NUMBER = "2.6"
+NUMBER = "2.7"
 VERSION = f"{NAME} {NUMBER}"
 
 REPLACE_TARGET = '_CBMC_STARTER_KIT_VERSION_'


### PR DESCRIPTION
Versions 2.6 and 2.7 are identical.  Failures in the publication workflow that only partially published 2.6 (package already published to pypi, pull request already pushed to brew tap) make it easier to bump the version number again and republish.

