### PR TITLE
Remove migrate-license subcommand

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ cbmc_starter_kit =
 
 [options.entry_points]
 console_scripts =
-    cbmc-starter-kit-migrate-license = cbmc_starter_kit.migrate_license:main
     cbmc-starter-kit-setup = cbmc_starter_kit.setup:main
     cbmc-starter-kit-setup-proof = cbmc_starter_kit.setup_proof:main
     cbmc-starter-kit-update = cbmc_starter_kit.update:main

--- a/src/cbmc_starter_kit/etc/bash_completion.d/cbmc-starter-kit.sh
+++ b/src/cbmc_starter_kit/etc/bash_completion.d/cbmc-starter-kit.sh
@@ -20,7 +20,6 @@ common_options="--help -h --verbose --debug --version"
 setup_options=""
 setup_proof_options=""
 update_options="--cbmc-root --starter-kit-root --no-migrate --no-test-removal --no-update --remove-starter-kit-submodule --remove-litani-submodule"
-migrate_options="--proofdir --remove"
 
 _core_autocomplete()
 {
@@ -55,12 +54,6 @@ _update_autocomplete()
   _core_autocomplete "$update_options"
 }
 
-_migrate_autocomplete()
-{
-  _core_autocomplete "$migrate_options"
-}
-
 complete -F _setup_autocomplete cbmc-starter-kit-setup
 complete -F _setup_proof_autocomplete cbmc-starter-kit-setup-proof
 complete -F _update_autocomplete cbmc-starter-kit-update
-complete -F _migrate_autocomplete cbmc-starter-kit-migrate-license


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This command no longer needs to be included in the CBMC starter-kit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
