### PR TITLE
Remove flags from update submcommand

### DIFF
--- a/src/cbmc_starter_kit/etc/bash_completion.d/cbmc-starter-kit.sh
+++ b/src/cbmc_starter_kit/etc/bash_completion.d/cbmc-starter-kit.sh
@@ -19,7 +19,7 @@ common_options="--help -h --verbose --debug --version"
 
 setup_options=""
 setup_proof_options=""
-update_options="--cbmc-root --starter-kit-root --no-migrate --no-test-removal --no-update --remove-starter-kit-submodule --remove-litani-submodule"
+update_options="--cbmc-root --starter-kit-root --no-test-removal --no-update"
 
 _core_autocomplete()
 {

--- a/src/cbmc_starter_kit/repository.py
+++ b/src/cbmc_starter_kit/repository.py
@@ -72,7 +72,6 @@ def proofs_root(cwd='.', abspath=True):
 
 ################################################################
 # Discover the roots of
-#   * the litani submodule
 #   * the starter kit submodule
 
 def submodule_root(url, submodules=None, repo='.', abspath=True):
@@ -90,17 +89,6 @@ def submodule_root(url, submodules=None, repo='.', abspath=True):
     logging.debug("Can't find submodule '%s'", url)
     logging.debug("Found submodules = %s", submodules)
     return None
-
-
-def litani_root(submodules=None, repo='.', abspath=True):
-    """Root of litani submodule."""
-
-    repo = repository_root(repo)
-    submodules = submodules or git.Repo(repo).submodules
-    litani1 = 'https://github.com/awslabs/aws-build-accumulator'
-    litani2 = 'git@github.com:awslabs/aws-build-accumulator'
-    return (submodule_root(litani1, submodules, repo, abspath) or
-            submodule_root(litani2, submodules, repo, abspath))
 
 def starter_kit_root(submodules=None, repo='.', abspath=True):
     """Root of starter kit submodule."""

--- a/src/cbmc_starter_kit/repository.py
+++ b/src/cbmc_starter_kit/repository.py
@@ -71,40 +71,6 @@ def proofs_root(cwd='.', abspath=True):
     raise UserWarning(f"'{cwd}' has no ancestor named '{proofs}'")
 
 ################################################################
-# Discover the roots of
-#   * the starter kit submodule
-
-def submodule_root(url, submodules=None, repo='.', abspath=True):
-    """Look up path to root of submodule url in submodules."""
-
-    url = url.lower()
-    repo = repository_root(repo)
-    submodules = submodules or git.Repo(repo).submodules
-
-    for submodule in submodules:
-        if not submodule.url.lower() in [url, url+".git"]:
-            continue
-        return repo/submodule.path if abspath else Path(submodule.path)
-
-    logging.debug("Can't find submodule '%s'", url)
-    logging.debug("Found submodules = %s", submodules)
-    return None
-
-def starter_kit_root(submodules=None, repo='.', abspath=True):
-    """Root of starter kit submodule."""
-
-    repo = repository_root(repo)
-    submodules = submodules or git.Repo(repo).submodules
-    old_starter1 = 'https://github.com/awslabs/aws-templates-for-cbmc-proofs'
-    old_starter2 = 'git@github.com:awslabs/aws-templates-for-cbmc-proofs'
-    new_starter1 = 'https://github.com/model-checking/cbmc-starter-kit'
-    new_starter2 = 'git@github.com:model-checking/cbmc-starter-kit'
-    return (submodule_root(old_starter1, submodules, repo, abspath) or
-            submodule_root(old_starter2, submodules, repo, abspath) or
-            submodule_root(new_starter1, submodules, repo, abspath) or
-            submodule_root(new_starter2, submodules, repo, abspath))
-
-################################################################
 # Discover the set of all source files in the repository that define a
 # function named func.
 

--- a/src/cbmc_starter_kit/setup.py
+++ b/src/cbmc_starter_kit/setup.py
@@ -37,7 +37,6 @@ SRCDIR ?= {}
 LITANI_TEXT = """
 # How to invoke litani.
 # Use "litani" when litani is present in PATH.
-# Use an absolute path when litani is included as a git submodule.
 #
 LITANI ?= {}
 """

--- a/src/cbmc_starter_kit/update.py
+++ b/src/cbmc_starter_kit/update.py
@@ -10,13 +10,8 @@ import logging
 import platform
 import re
 import shutil
-import subprocess
-import sys
-
-import git
 
 from cbmc_starter_kit import arguments
-from cbmc_starter_kit import repository
 from cbmc_starter_kit import util
 from cbmc_starter_kit import version
 
@@ -29,12 +24,6 @@ def parse_arguments():
          'type': Path,
          'metavar': 'CBMC',
          'help': 'Root of CBMC proof infrastructure (default: ".")'},
-        {'flag': '--starter-kit-root',
-         'type': Path,
-         'metavar': 'STARTER_KIT',
-         'help': """
-          Root of CBMC starter kit submodule (default: None or root of starter kit submodule
-          installed in repository containing CBMC)"""},
         {'flag': '--no-migrate',
          'action': 'store_true',
          'help': """
@@ -50,12 +39,7 @@ def parse_arguments():
          'action': 'store_true',
          'help': """
           Do not update Makefile.common and run-cbmc-proofs.py under CBMC/proofs.
-          Normally update these files with the versions in the starter kit package."""},
-        {'flag': '--remove-starter-kit-submodule',
-         'action': 'store_true',
-         'help': """
-          Remove the starter kit submodule if it is present.
-          Normally just recommend removal."""},
+          Normally update these files with the versions in the starter kit package."""}
     ]
     args = arguments.create_parser(
         options=options,
@@ -75,64 +59,7 @@ def validate_cbmc_root(args):
     logging.debug('CBMC root: %s', args.cbmc_root)
     return args
 
-def validate_starter_kit_root(args):
-    starter_kit = repository.starter_kit_root(repo=args.cbmc_root, abspath=True)
-    args.starter_kit_root = args.starter_kit_root or starter_kit
-    if args.starter_kit_root:
-        args.starter_kit_root = args.starter_kit_root.resolve()
-        if not args.starter_kit_root.is_dir():
-            raise UserWarning(f'Starter kit root is not a directory: {args.starter_kit_root}')
-        if not (args.starter_kit_root/util.REPOSITORY_TEMPLATES).is_dir():
-            raise UserWarning(f'Starter kit root is missing a {util.REPOSITORY_TEMPLATES} '
-                              f'subdirectory: {args.starter_kit_root}')
-        if args.cbmc_root not in args.starter_kit_root.parents:
-            raise UserWarning(f'Starter kit root is {args.starter_kit_root} is not a descendant of '
-                              f'CBMC root {args.cbmc_root}')
-    else:
-        args.no_migrate = True
-    logging.debug('CBMC starter kit root: %s', args.starter_kit_root)
-    return args
-
 ################################################################
-
-def files_under_root(root=None, symlinks_only=False):
-    if root and not root.is_dir():
-        logging.critical('Not a directory: %s', root)
-        sys.exit(1)
-
-    cmd = ['find', '.']
-    if symlinks_only:
-        cmd += ['-type', 'l']
-    kwds = {
-        'cwd': root,
-        'text': True,
-        'capture_output': True,
-    }
-    result = subprocess.run(cmd, **kwds, check=True)
-
-    if not result.returncode:
-        return sorted(result.stdout.splitlines())
-    logging.critical('This should be impossible: Failed to list files under directory: %s', root)
-    sys.exit(1)
-
-################################################################
-
-def remove_submodule(cbmc_root, submodule_name, submodule_path):
-    """Remove the submodule at the named path in the repository"""
-
-    for submodule in git.Repo(cbmc_root, search_parent_directories=True).submodules:
-        if submodule.path == str(submodule_path):
-            logging.info('Removing: %s submodule: %s', submodule_name, submodule_path)
-            try:
-                submodule.remove()
-            except git.InvalidGitRepositoryError as error:
-                # remove uses git cherry to compare working branches with upstream branches
-                # and throws InvalidGitRepositoryError if it finds an inconsistency.
-                logging.debug(error)
-                logging.error('Unable to remove %s submodule: %s',  submodule_name, submodule_path)
-                logging.error('Try again after running "git fetch" in %s', submodule_path)
-            return
-    logging.error("Failed to remove %s submodule: %s", submodule_name, submodule_path)
 
 def update_litani_makefile_variable(cbmc_root, path):
     """Update LITANI to LITANI?=litani in the makefile at the named path"""
@@ -155,23 +82,6 @@ def update_litani_makefile_variable(cbmc_root, path):
 
 ################################################################
 
-def migrate(cbmc_root, starter_kit_root):
-    logging.debug('Migrating CBMC starter kit')
-    templates = files_under_root(starter_kit_root/util.REPOSITORY_TEMPLATES)
-    logging.debug('Migrating CBMC starter kit: found templates: %s', templates)
-    symlinks = files_under_root(cbmc_root, symlinks_only=True)
-    logging.debug('Migrating CBMC starter kit: found symlinks: %s', symlinks)
-
-    cbmc_symlinks = [path for path in templates if path in symlinks]
-    for symlink in cbmc_symlinks:
-        cbmc_link = cbmc_root / symlink
-        cbmc_file = cbmc_link.resolve()
-        logging.info('Copying: %s -> %s', cbmc_file, cbmc_link)
-        assert cbmc_file.exists()
-        assert cbmc_link.exists()
-        cbmc_link.unlink()
-        shutil.copy(cbmc_file, cbmc_link)
-
 def remove_negative_tests(cbmc_root):
     logging.debug('Removing CBMC starter kit negative tests')
     negative_tests = cbmc_root / util.NEGATIVE_TESTS
@@ -190,19 +100,6 @@ def update(cbmc_root, quiet=False):
             shutil.copytree(src, dst, dirs_exist_ok=True)
         else:
             version.copy_with_version(src, dst)
-
-def check_for_starter_kit_submodule(cbmc_root, remove=False):
-    starter_path = repository.starter_kit_root(repo=cbmc_root, abspath=False)
-    if not starter_path:
-        logging.debug("Found starter kit submodule is not installed")
-        return
-
-    if not remove:
-        logging.warning("Consider using --remove-starter-kit-submodule to remove the starter kit "
-                        "submodule")
-        return
-
-    remove_submodule(cbmc_root, "starter kit", starter_path)
 
 def check_for_litani(cbmc_root):
     if shutil.which('litani'):
@@ -224,34 +121,19 @@ def check_for_litani(cbmc_root):
 ################################################################
 
 def main():
-    """Migrate CBMC starter kit from submodule to pip package."""
+    """Update files, that were previously added, during installation of the
+    CBMC starter kit package."""
 
     args = parse_arguments()
     logging.debug('args: %s', args)
 
-    try:
-        args = validate_cbmc_root(args)
-        args = validate_starter_kit_root(args)
+    args = validate_cbmc_root(args)
 
-        if not args.no_migrate:
-            migrate(args.cbmc_root, args.starter_kit_root)
-        if not args.no_test_removal:
-            remove_negative_tests(args.cbmc_root)
-        if not args.no_update:
-            update(args.cbmc_root)
-        check_for_starter_kit_submodule(args.cbmc_root, args.remove_starter_kit_submodule)
-        check_for_litani(args.cbmc_root)
-    except UserWarning:
-        starter_kit = repository.starter_kit_root(repo=args.cbmc_root)
-        if starter_kit and (starter_kit / "setup.cfg").exists():
-            logging.error("The starter kit submodule is at a version >1.0: %s", starter_kit)
-            logging.error("Consider backing up to version 1.0 with the following commands")
-            logging.error("  pushd %s", starter_kit)
-            logging.error("  git fetch --tags")
-            logging.error("  git checkout starterkit-1.0")
-            logging.error("  popd")
-            logging.error("and running cbmc-starter-kit-update again with --remove-starter-kit.")
-        raise
+    if not args.no_test_removal:
+        remove_negative_tests(args.cbmc_root)
+    if not args.no_update:
+        update(args.cbmc_root)
+    check_for_litani(args.cbmc_root)
 
 ################################################################
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The 2 deleted flags would remove the CBMC starter kit, Litani submodules, if a project had configured their C project to use those 2 as submodules.

As a result of this change, all users of the CBMC starter kit will have to install it (and Litani) as a package.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
