### PR TITLE
Add feature enabling GitHub Actions CI workflow to upload, serve CBMC proof artifacts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ package_dir =
 packages = find:
 include_package_data = True
 install_requires =
+    boto3
     gitpython
     setuptools
 python_requires = >=3.8

--- a/src/cbmc_starter_kit/setup_ci.py
+++ b/src/cbmc_starter_kit/setup_ci.py
@@ -5,11 +5,15 @@
 
 """Set up the AWS infrastructure to run proofs in CI."""
 
+import json
 import logging
 import re
 import shutil
 from argparse import RawDescriptionHelpFormatter
 
+import boto3
+import botocore.exceptions
+import git
 
 from cbmc_starter_kit import arguments, repository, util
 
@@ -19,7 +23,9 @@ def parse_arguments():
     """Parse arguments for cbmc-starter-kit-setup-ci command"""
     desc = """
     Adds a worflow and other resource files, such that CBMC proofs are executed
-    in GitHub Actions as part of CI.
+    in GitHub Actions as part of CI. If your project is a public GitHub repo,
+    you can elect to deploy infrastructure to AWS, so that you can later browse
+    CI artifacts online.
 
     The most recently released and available versions of CBMC, CBMC viewer,
     Litani, kissat and cadical will be used by default. In the cases of CBMC,
@@ -44,6 +50,14 @@ def parse_arguments():
                 proofs inside of GitHub Actions. For example: 'ubuntu-20.04'
                 If you have created a large runner for your repo, you can
                 specify its name."""
+        }, {
+        'flag': '--aws-account-id',
+        'type': lambda x: x if x.isdigit() and len(x) == 12 else False,
+        'help': """
+                ID of the AWS account where AWS CloudFormation stacks will be
+                deployed such that CI artifacts can be viewed online.
+                This option should be used only by public GitHub repositories.
+                """
         }, {
         'flag': '--cbmc',
         'metavar': '<latest>|<X.Y.Z>',
@@ -79,6 +93,132 @@ def parse_arguments():
 
 ################################################################
 
+def _get_template_body(cf_client, cfn_path, stack_name):
+    template = cfn_path / f"{stack_name}.yaml"
+    with open(template) as template_fileobj:
+        template_data = template_fileobj.read()
+    cf_client.validate_template(TemplateBody=template_data)
+    return template_data
+
+def _stack_exists(cf_client, stack_name):
+    stacks = cf_client.list_stacks()["StackSummaries"]
+    for stack in stacks:
+        if stack["StackStatus"] == "DELETE_COMPLETE":
+            continue
+        if stack_name == stack["StackName"]:
+            return True
+    return False
+
+def _deploy_stack(cf_client, params):
+    """Update or create AWS CloudFormation stack"""
+    stack_name = params["StackName"]
+    try:
+        if _stack_exists(cf_client, stack_name):
+            logging.info("Updating %s", stack_name)
+            stack_result = cf_client.update_stack(**params)
+            waiter = cf_client.get_waiter("stack_update_complete")
+        else:
+            logging.info("Creating %s", stack_name)
+            stack_result = cf_client.create_stack(**params)
+            waiter = cf_client.get_waiter("stack_create_complete")
+        logging.info("Waiting for stack operation to complete...")
+        waiter.wait(StackName=stack_name)
+    except botocore.exceptions.ClientError as ex:
+        error_message = ex.response["Error"]["Message"]
+        if error_message != "No updates are to be performed.":
+            logging.error(
+                "When updating stack, unexpected error encountered: %s",
+                stack_name,
+            )
+            raise
+        print(f"No updates are to be performed for stack {stack_name}")
+    else:
+        logging.info(json.dumps(stack_result, indent=4))
+
+def _deploy_stacks(cf_client, cfn_path, repo_owner, repo_name, repo_id):
+    """
+    Deploy AWS CloudFormation stacks. Return domain of CloudFront distribution
+    """
+    if not _stack_exists(cf_client, util.CFN_STACK_OIDC):
+        _deploy_stack(
+            cf_client,
+            params={
+                "StackName": util.CFN_STACK_OIDC,
+                "TemplateBody": _get_template_body(
+                    cf_client, cfn_path, util.CFN_STACK_OIDC),
+            },
+        )
+    pipeline_stack = f"{util.CFN_STACK_PIPELINE}-{repo_id}"
+    _deploy_stack(
+        cf_client,
+        params={
+            "StackName": pipeline_stack,
+            "TemplateBody": _get_template_body(
+                    cf_client, cfn_path, util.CFN_STACK_PIPELINE),
+            "Parameters": [
+                {"ParameterKey": k, "ParameterValue": v}
+                for k, v in {
+                    "GitHubRepoOwner": repo_owner,
+                    "GitHubRepoName": repo_name,
+                    "GitHubRepoId": str(repo_id)
+                }.items()
+            ],
+            "Capabilities": ["CAPABILITY_NAMED_IAM"],
+            "Tags": [
+                {"Key": "owner", "Value": repo_owner},
+                {"Key": "repo", "Value": repo_name}
+            ],
+        },
+    )
+    print(
+        "Visit:\n\n"
+        f"https://github.com/{repo_owner}/{repo_name}/settings/secrets/actions\n")
+    print(
+        "and add a \"PROOF_CI_IAM_ROLE\" secret to your GitHub repository's "
+        "secrets used in GitHub Actions.\nThe secret must have this value:\n")
+    response = cf_client.describe_stacks(StackName=pipeline_stack)
+    outputs = response["Stacks"][0]["Outputs"]
+    aws_cloudfront_domain = "''"
+    for output in outputs:
+        key_name = output["OutputKey"]
+        if key_name == "ProofActionsRoleArn":
+            print(output["OutputValue"])
+        elif key_name == "ProofCIDistributionDomainName":
+            aws_cloudfront_domain = output["OutputValue"]
+    return aws_cloudfront_domain
+
+def deploy(aws_account_id, cfn_path, repo_owner, repo_name, repo_id):
+    """
+    Deploy to AWS the infrastructure in the form of AWS CFN stacks needed to run
+    CBMC proofs as part of CI.
+
+    Return domain of CloudFront distribution that will serve CI artifacts
+    """
+    aws_cloudfront_domain = "''"
+    try:
+        sts_client = boto3.client("sts")
+        cf_client = boto3.client("cloudformation")
+        response = sts_client.get_caller_identity()
+        if aws_account_id == response["Account"]:
+            logging.info(
+                "AWS credentials for account %s found", response["Account"])
+            print("Deploying CI infrastructure to AWS CloudFormation...")
+            aws_cloudfront_domain = _deploy_stacks(
+                cf_client, cfn_path, repo_owner, repo_name, repo_id)
+        else:
+            logging.error(
+                "AWS credentials for %s not found", response["Account"])
+    except (
+        botocore.exceptions.ClientError,
+        botocore.exceptions.NoCredentialsError,
+    ) as error:
+        error_message = error.response["Error"]["Message"]
+        logging.exception(
+            "Failed to deploy CI infrastructure: %s", error_message)
+    return aws_cloudfront_domain
+
+################################################################
+
 def _read_file_template(path):
     """Read file and return list of lines"""
     with open(path, encoding='utf-8') as data:
@@ -111,11 +251,12 @@ def _replace_placeholders_in_workflow_template(lines, replacements):
             buf.append(line.replace(f"<__{key}__>", replacements[key]))
     return buf
 
-def patch_proof_ci_workflow(args, proof_ci_path):
+def patch_proof_ci_workflow(args, aws_cloudfront_domain, proof_ci_path):
     """Patch GitHub Actions workflow with appropriate values"""
     lines = _read_file_template(proof_ci_path)
     proofs_dir = repository.get_relative_path_from_repository_to_proofs_root()
     replacements = {
+        "AWS_CLOUDFRONT_DOMAIN": aws_cloudfront_domain,
         "CADICAL_TAG": args.cadical,
         "CBMC_VERSION": args.cbmc,
         "CBMC_VIEWER_VERSION": args.cbmc_viewer,
@@ -146,18 +287,33 @@ def main():
     Creates a GitHub Actions workflow file based on the provided input.
     """
     args = parse_arguments()
+    aws_account_id = args.aws_account_id
     repo_root = repository.repository_root()
+    repo_url_segments = (
+        git.Repo(repo_root).remotes.origin.url.split(".git")[0].split("/"))
+    repo_owner, repo_name = repo_url_segments[-2], repo_url_segments[-1]
 
     github_actions_workflows_path = repository.github_actions_workflows_root()
     workflow_path = github_actions_workflows_path / util.GITHUB_ACTIONS_PROOF_CI
+    cfn_path = github_actions_workflows_path / util.PROOF_CI_AWS_CFN_STACKS
 
     shutil.copytree(
         util.package_ci_workflow_template_root(),
         github_actions_workflows_path,
         dirs_exist_ok=True)
 
-    patch_proof_ci_workflow(args, workflow_path)
+    aws_cloudfront_domain = "''"
+    if aws_account_id:
+        repo_details = util.get_repository_details(repo_owner, repo_name)
+        repo_id = repo_details["id"]
+        aws_cloudfront_domain = deploy(
+            aws_account_id, cfn_path, repo_owner, repo_name, repo_id)
+
+    patch_proof_ci_workflow(args, aws_cloudfront_domain, workflow_path)
     add_or_update_summarize_module(repo_root, quiet=not args.debug)
+    if aws_cloudfront_domain == "''":
+        for filename in cfn_path.iterdir():
+            filename.unlink()
 
 if __name__ == "__main__":
     main()

--- a/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
+++ b/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
@@ -21,9 +21,22 @@ on:
 # If your repository has large runners at its disposal, then the value for this
 # key can be set to the name of your large runner. Find more details at:
 # https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners
+#
+# If you seek to use AWS to upload CI artifacts to S3 and to later view in your
+# browser an HTML version of the CBMC proof report, then you need to provide
+# values for:
+#
+# - AWS_CLOUDFRONT_DOMAIN can be something like 'd111111abcdef8.cloudfront.net'
+# - AWS_REGION is set to 'us-east-1', but you can change this to the AWS region
+#   in which the necessary AWS CloudFormation stacks have been deployed
+# - AWS_ROLE_DURATION_SECONDS specifies the allotted time for which a session
+#   will be valid for the IAM role that has been configured.
 
 
 env:
+  AWS_CLOUDFRONT_DOMAIN: <__AWS_CLOUDFRONT_DOMAIN__>
+  AWS_REGION: us-east-1
+  AWS_ROLE_DURATION_SECONDS: 3600
   CADICAL_TAG: <__CADICAL_TAG__>
   CBMC_VERSION: <__CBMC_VERSION__>
   CBMC_VIEWER_VERSION: <__CBMC_VIEWER_VERSION__>
@@ -236,11 +249,40 @@ jobs:
         with:
           name: ${{ steps.artifact.outputs.name }}
           path: ${{ steps.artifact.outputs.name }}.zip
+      - name: Set S3 URI
+        id: s3_uri
+        if: ${{ env.AWS_CLOUDFRONT_DOMAIN != '' }}
+        run: echo "name=BuildArtifacts/${{ github.event.after }}/final" >> $GITHUB_OUTPUT
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        if: ${{ env.AWS_CLOUDFRONT_DOMAIN != '' }}
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: ${{ env.AWS_ROLE_DURATION_SECONDS }}
+          role-session-name: cbmc_ci
+          role-to-assume: ${{ secrets.PROOF_CI_IAM_ROLE }}
+      - name: Upload CBMC proof results to S3
+        id: aws_upload
+        if: ${{ env.AWS_CLOUDFRONT_DOMAIN != '' }}
+        shell: bash
+        run: |
+          aws s3 sync \
+            $PROOFS_DIR/output/latest/html \
+            s3://proof-ci-artifacts-${{ fromJson(toJson(github.event.repository)).id }}/${{ steps.s3_uri.outputs.name }} \
+            --only-show-errors
       - name: CBMC proof results
         shell: bash
         run: |
-          python3 ${{ env.PROOFS_DIR }}/lib/summarize.py \
-            --run-file ${{ env.PROOFS_DIR }}/output/latest/html/run.json > summary.md
+          if [ -n "${{ env.AWS_CLOUDFRONT_DOMAIN }}" ]
+          then
+            python3 ${{ env.PROOFS_DIR }}/lib/summarize.py \
+              --cloudfront-domain ${{ env.AWS_CLOUDFRONT_DOMAIN }} \
+              --s3-uri ${{ steps.s3_uri.outputs.name }} \
+              --run-file ${{ env.PROOFS_DIR }}/output/latest/html/run.json > summary.md
+          else
+            python3 ${{ env.PROOFS_DIR }}/lib/summarize.py \
+              --run-file ${{ env.PROOFS_DIR }}/output/latest/html/run.json > summary.md
+          fi
           cat summary.md >> $GITHUB_STEP_SUMMARY
           cat summary.md
           cat summary.md | [[ $(grep -cim1 -e "fail" -e "in progress") -eq 0 ]] ; echo $?

--- a/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci_aws_cfn_stacks/proof-ci-Oidc.yaml
+++ b/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci_aws_cfn_stacks/proof-ci-Oidc.yaml
@@ -1,0 +1,16 @@
+Resources:
+  GithubOIDC:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      ThumbprintList:
+        # Source: https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
+      ClientIdList:
+        - sts.amazonaws.com
+      Url: https://token.actions.githubusercontent.com
+Outputs:
+  GitHubOidcProviderArn:
+    Value:
+      Ref: GithubOIDC
+    Export:
+      Name: GitHubOidcProviderArn

--- a/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci_aws_cfn_stacks/proof-ci-Pipeline.yaml
+++ b/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci_aws_cfn_stacks/proof-ci-Pipeline.yaml
@@ -1,0 +1,196 @@
+Parameters:
+  GitHubRepoOwner:
+    Type: String
+  GitHubRepoName:
+    Type: String
+  GitHubRepoId:
+    Type: String
+Resources:
+  CiArtifactsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - BucketKeyEnabled: false
+            ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      BucketName:
+        Fn::Join:
+          - "-"
+          - - "proof-ci-artifacts"
+            - Ref: GitHubRepoId
+  ProofActionsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+              StringLike:
+                token.actions.githubusercontent.com:sub:
+                  - Fn::Join:
+                      - ""
+                      - - "repo:"
+                        - Ref: GitHubRepoOwner
+                        - "/"
+                        - Ref: GitHubRepoName
+                        - :*
+            Effect: Allow
+            Principal:
+              Federated:
+                Fn::ImportValue: GitHubOidcProviderArn
+        Version: "2012-10-17"
+      Description: This role is used by GitHub Actions to upload Litani HTML reports.
+      MaxSessionDuration: 7200
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - s3:ListBucket
+                Effect: Allow
+                Resource:
+                  Fn::GetAtt:
+                    - CiArtifactsBucket
+                    - Arn
+              - Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Effect: Allow
+                Resource:
+                  Fn::Join:
+                    - ""
+                    - - Fn::GetAtt:
+                          - CiArtifactsBucket
+                          - Arn
+                      - /*
+            Version: "2012-10-17"
+          PolicyName: s3
+      RoleName:
+        Fn::Join:
+          - "-"
+          - - "proof-ci-actions-role"
+            - Ref: GitHubRepoId
+    DependsOn:
+      - CiArtifactsBucket
+  ProofCICloudFrontOriginAccessIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: Origin Access Identity to be granted read-access to S3 bucket with CI artifacts
+  ProofCICloudFrontOAIPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket:
+        !Ref CiArtifactsBucket
+      PolicyDocument:
+        Statement:
+          - Action: s3:GetObject
+            Effect: Allow
+            Principal:
+              CanonicalUser:
+                Fn::GetAtt:
+                  - ProofCICloudFrontOriginAccessIdentity
+                  - S3CanonicalUserId
+            Resource:
+              Fn::Join:
+                - ""
+                - - Fn::GetAtt:
+                      - CiArtifactsBucket
+                      - Arn
+                  - /*
+        Version: "2012-10-17"
+    DependsOn:
+      - ProofCICloudFrontOriginAccessIdentity
+  ProofCIDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - GET
+            - HEAD
+          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          CachedMethods:
+            - GET
+            - HEAD
+          Compress: true
+          TargetOriginId:
+            Fn::GetAtt:
+              - ProofCICloudFrontOriginAccessIdentity
+              - Id
+          ViewerProtocolPolicy: redirect-to-https
+        DefaultRootObject: index.html
+        Enabled: true
+        Origins:
+          - ConnectionAttempts: 3
+            ConnectionTimeout: 10
+            DomainName:
+              Fn::Join:
+                - ""
+                - - !Ref CiArtifactsBucket
+                  - .s3.
+                  - Ref: AWS::Region
+                  - .amazonaws.com
+            Id:
+              Fn::GetAtt:
+                - ProofCICloudFrontOriginAccessIdentity
+                - Id
+            OriginShield:
+              Enabled: false
+              OriginShieldRegion:
+                Ref: AWS::Region
+            S3OriginConfig:
+              OriginAccessIdentity:
+                Fn::Join:
+                  - ""
+                  - - origin-access-identity/cloudfront/
+                    - Fn::GetAtt:
+                        - ProofCICloudFrontOriginAccessIdentity
+                        - Id
+    DependsOn:
+      - ProofCICloudFrontOriginAccessIdentity
+Outputs:
+  CiArtifactsS3Bucket:
+    Value:
+      !Ref CiArtifactsBucket
+    Export:
+      Name:
+        Fn::Join:
+          - "-"
+          - - "CiArtifactsS3Bucket"
+            - Ref: GitHubRepoId
+  CiArtifactsS3BucketArn:
+    Value:
+      Fn::GetAtt:
+        - CiArtifactsBucket
+        - Arn
+    Export:
+      Name:
+        Fn::Join:
+          - "-"
+          - - "CiArtifactsS3BucketArn"
+            - Ref: GitHubRepoId
+  ProofActionsRoleArn:
+    Value:
+      Fn::GetAtt:
+        - ProofActionsRole
+        - Arn
+    Export:
+      Name:
+        Fn::Join:
+          - "-"
+          - - "ProofActionsRoleArn"
+            - Ref: GitHubRepoId
+  ProofCIDistributionDomainName:
+    Value:
+      Fn::GetAtt:
+        - ProofCIDistribution
+        - DomainName
+    Export:
+      Name:
+        Fn::Join:
+          - "-"
+          - - "ProofCIDistributionDomainName"
+            - Ref: GitHubRepoId

--- a/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
@@ -8,15 +8,30 @@ import logging
 
 DESCRIPTION = """Print 2 tables in GitHub-flavored Markdown that summarize
 an execution of CBMC proofs."""
+EPILOG = """The CloudFront domain and the S3 URI should either be specified
+ together or they should not be specified altogether."""
 
 
 def get_args():
     """Parse arguments for summarize script."""
-    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG)
     for arg in [{
             "flags": ["--run-file"],
             "help": "path to the Litani run.json file",
             "required": True,
+        }, {
+            "flags": ["--cloudfront-domain"],
+            "help": "the domain of the Amazon CloudFront distribution that is "
+                    "serving CBMC proof reports, which were uploaded to S3"
+                    "during the execution of the GitHub Actions workflow."
+                    "Usage of this flag necessitates usage of --s3-uri"
+                    "For example: d111111abcdef8.cloudfront.net"
+        }, {
+            "flags": ["--s3-uri"],
+            "help": "the key to a directory within a S3 bucket holding all "
+                    "artifacts for a CBMC proof report."
+                    "Usage of this flag necessitates usage of --cloudfront-domain"
+                    "For example: BuildArtifacts/abcdef/final"
     }]:
         flags = arg.pop("flags")
         parser.add_argument(*flags, **arg)
@@ -65,7 +80,7 @@ def _get_rendered_table(data):
     return "".join(table)
 
 
-def _get_status_and_proof_summaries(run_dict):
+def _get_status_and_proof_summaries(run_dict, cloudfront_domain=None, s3_uri=None):
     """Parse a dict representing a Litani run and create lists summarizing the
     proof results.
 
@@ -73,7 +88,14 @@ def _get_status_and_proof_summaries(run_dict):
     ----------
     run_dict
         A dictionary representing a Litani run.
-
+    cloudfront_domain
+        A string representing the domain of the CloudFront distribution, which
+        serves CBMC proof results that areuploaded to an associated S3 bucket.
+        For example: d111111abcdef8.cloudfront.net
+    s3_uri
+        The key to a directory within a S3 bucket holding all artifacts for a
+        CBMC proof report.
+        For example: BuildArtifacts/abcdef/final
 
     Returns
     -------
@@ -83,6 +105,8 @@ def _get_status_and_proof_summaries(run_dict):
     """
     count_statuses = {}
     proofs = [["Proof", "Status"]]
+    if cloudfront_domain:
+        proofs[0].append("CBMC proof report")
     for proof_pipeline in run_dict["pipelines"]:
         status_pretty_name = proof_pipeline["status"].title().replace("_", " ")
         try:
@@ -91,13 +115,20 @@ def _get_status_and_proof_summaries(run_dict):
             count_statuses[status_pretty_name] = 1
         proof = proof_pipeline["name"]
         proofs.append([proof, status_pretty_name])
+    if cloudfront_domain:
+        for i in range(1, len(proofs)):
+            proof = proofs[i][0]
+            final_report = f"https://{cloudfront_domain}/{s3_uri}"
+            viewer_proof_artifact = f"artifacts/{proof}/report/html/index.html"
+            viewer_html_report_url = f"{final_report}/{viewer_proof_artifact}"
+            proofs[i].append(f"[Details]({viewer_html_report_url})")
     statuses = [["Status", "Count"]]
     for status, count in count_statuses.items():
         statuses.append([status, str(count)])
     return [statuses, proofs]
 
 
-def print_proof_results(out_file):
+def print_proof_results(out_file, cloudfront_domain=None, s3_uri=None):
     """
     Print 2 strings that summarize the proof results.
     When printing, each string will render as a GitHub flavored Markdown table.
@@ -107,7 +138,7 @@ def print_proof_results(out_file):
         with open(out_file, encoding='utf-8') as run_json:
             run_dict = json.load(run_json)
             summaries = _get_status_and_proof_summaries(
-                run_dict)
+                run_dict, cloudfront_domain=cloudfront_domain, s3_uri=s3_uri)
             for summary in summaries:
                 print(_get_rendered_table(summary))
     except Exception as ex: # pylint: disable=broad-except
@@ -116,4 +147,19 @@ def print_proof_results(out_file):
 
 if __name__ == '__main__':
     args = get_args()
-    print_proof_results(args.run_file)
+    with_aws = args.cloudfront_domain and args.s3_uri
+    without_aws = not args.cloudfront_domain and not args.s3_uri
+    if not with_aws and not without_aws:
+        raise argparse.ArgumentTypeError(
+            "The CloudFront domain and the S3 URI should either be specified "
+            "together or they should not be specified altogether.")
+    if with_aws:
+        CBMC_PROOF_REPORT_HEADER = "Click here to see the CBMC proof report"
+        url = f"https://{args.cloudfront_domain}/{args.s3_uri}/index.html"
+        print(f"## [{CBMC_PROOF_REPORT_HEADER}]({url})")
+        print_proof_results(
+            args.run_file,
+            cloudfront_domain=args.cloudfront_domain,
+            s3_uri=args.s3_uri)
+    elif without_aws:
+        print_proof_results(args.run_file)

--- a/src/cbmc_starter_kit/util.py
+++ b/src/cbmc_starter_kit/util.py
@@ -4,13 +4,18 @@
 """Methods of manipulating the templates repository."""
 
 import importlib.util
+import json
+import sys
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
 
 from cbmc_starter_kit import repository
 
 REPOSITORY_TEMPLATES = "template-for-repository"
 PROOF_TEMPLATES = "template-for-proof"
 CI_WORKFLOW_TEMPLATES = "template-for-ci-workflow"
+PROOF_CI_AWS_CFN_STACKS = "proof_ci_aws_cfn_stacks"
 PROOF_DIR = "proofs"
 LIB_MODULE = "lib"
 NEGATIVE_TESTS = "negative_tests"
@@ -74,6 +79,29 @@ def package_proof_template_root():
 
 def package_ci_workflow_template_root():
     return package_root() / CI_WORKFLOW_TEMPLATES
+
+def get_repository_details(repo_owner, repo_name):
+    endpoint = f"https://api.github.com/repos/{repo_owner}/{repo_name}"
+    try:
+        with urlopen(endpoint, timeout=10) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as error:
+        print(error.status, error.reason)
+        if error.status == 403:
+            print(f"You don't have access to {repo_owner}/{repo_name}")
+        elif error.status == 404:
+            print(
+                f"{repo_owner}/{repo_name} is either private or doesn't exist")
+            print(
+                "If the repository is private, please run "
+                "`cbmc-starter-kit-setup-ci` without providing an AWS account")
+        sys.exit(1)
+    except URLError as error:
+        print(error.reason)
+        sys.exit(1)
+    except TimeoutError:
+        print("Request timed out")
+        sys.exit(1)
 
 ################################################################
 # Ask the user for set up information


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Repositories can integrate with AWS their GitHub Actions workflow, which is responsible for executing CBMC proofs as part of CI.

An integration with AWS works as follows:
  1. A developer installs the latest `cbmc-starter-kit` ([instructions](https://github.com/model-checking/cbmc-starter-kit#installation))
  2. A developer gets valid credentials for their AWS account ([configuring the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)).
  3. A developer then runs `cbmc-starter-kit-setup-ci --github-actions-runner <github-actions-runner> --aws-account-id <aws-account-id> --verbose`. This will deploy stacks with the minimal infrastructure to AWS CloudFormation.
  4. The developer follows the instruction printed in the terminal output and copies the ARN of the created IAM role and enters it as the value of a new secret in their GitHub repository.
  5. The developer pushes a commit containing the workflow as well as the AWS CloudFormation stack templates to their project's remote.
  6. The CI starts running. The "Summary" page will contain links to the detailed CBMC proof HTML report as well as tables summarizing the results of the execution of proofs. The logs of the GitHub Actions will contain the same table summaries.

All in all, the behavior of the CI is as follows:
  - CBMC proofs are being executed inside of the GitHub Actions machine.
  - Artifacts are uploaded to a Amazon S3 bucket.
 - The S3 bucket is "associated to a CloudFront distribution. Users can view online detailed logs from CBMC and artifacts from CBMC viewer by clicking on the link to the hosted CBMC proof report.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
