### PR TITLE
Print versions of all tools to front Litani page

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,3 +49,4 @@ console_scripts =
     cbmc-starter-kit-setup = cbmc_starter_kit.setup:main
     cbmc-starter-kit-setup-proof = cbmc_starter_kit.setup_proof:main
     cbmc-starter-kit-update = cbmc_starter_kit.update:main
+    cbmc-starter-kit-print-tool-versions = cbmc_starter_kit.print_tool_versions:main

--- a/src/cbmc_starter_kit/print_tool_versions.py
+++ b/src/cbmc_starter_kit/print_tool_versions.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+
+import logging
+import pathlib
+import shutil
+import subprocess
+
+
+_TOOLS = [
+    "cadical",
+    "cbmc",
+    "cbmc-viewer",
+    "cbmc-starter-kit-update",
+    "litani",
+]
+
+
+def _format_versions(table):
+    lines = [
+        "<table>",
+        '<tr><td colspan="2" style="font-weight: bold">Tool Versions</td></tr>',
+    ]
+    for tool, version in table.items():
+        if version:
+            v_str = f'<code><pre style="margin: 0">{version}</pre></code>'
+        else:
+            v_str = '<em>not found</em>'
+        lines.append(
+            f'<tr><td style="font-weight: bold; padding-right: 1em; '
+            f'text-align: right;">{tool}:</td>'
+            f'<td>{v_str}</td></tr>')
+    lines.append("</table>")
+    return "\n".join(lines)
+
+
+def _get_tool_versions():
+    ret = {}
+    for tool in _TOOLS:
+        err = f"Could not determine version of {tool}: "
+        ret[tool] = None
+        if not shutil.which(tool):
+            logging.error("%s'%s' not found on $PATH", err, tool)
+            continue
+        cmd = [tool, "--version"]
+        proc = subprocess.Popen(cmd, text=True, stdout=subprocess.PIPE)
+        try:
+            out, _ = proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            logging.error("%s'%s --version' timed out", err, tool)
+            continue
+        if proc.returncode:
+            logging.error(
+                "%s'%s --version' returned %s", err, tool, str(proc.returncode))
+            continue
+        ret[tool] = out.strip()
+    return ret
+
+
+def main():
+    exe_name = pathlib.Path(__file__).name
+    logging.basicConfig(format=f"{exe_name}: %(message)s")
+
+    table = _get_tool_versions()
+    out = _format_versions(table)
+    print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cbmc_starter_kit/template-for-repository/proofs/run-cbmc-proofs.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/run-cbmc-proofs.py
@@ -15,6 +15,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import uuid
 
 from lib.summarize import print_proof_results
 
@@ -333,6 +334,22 @@ async def configure_proof_dirs( # pylint: disable=too-many-arguments
         queue.task_done()
 
 
+def add_tool_version_job():
+    cmd = [
+        "litani", "add-job",
+        "--command", "cbmc-starter-kit-print-tool-versions .",
+        "--description", "printing out tool versions",
+        "--phony-outputs", str(uuid.uuid4()),
+        "--pipeline-name", "print_tool_versions",
+        "--ci-stage", "report",
+        "--tags", "front-page-text",
+    ]
+    proc = subprocess.run(cmd)
+    if proc.returncode:
+        logging.critical("Could not add tool version printing job")
+        sys.exit(1)
+
+
 async def main(): # pylint: disable=too-many-locals
     args = get_args()
     set_up_logging(args.verbose)
@@ -401,6 +418,8 @@ async def main(): # pylint: disable=too-many-locals
         tasks.append(task)
 
     await proof_queue.join()
+
+    add_tool_version_job()
 
     print_counter(counter)
     print("", file=sys.stderr)


### PR DESCRIPTION
The Litani dashboard for every proof run now includes a table indicating the versions of CBMC, CBMC Viewer, and other proof tools that were used in this run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
