### PR TITLE
[GitHub Actions CI] Enable uploading and online browsing of CBMC proof artifacts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ package_dir =
 packages = find:
 include_package_data = True
 install_requires =
+    boto3
     gitpython
     setuptools
 python_requires = >=3.8

--- a/src/cbmc_starter_kit/setup_ci.py
+++ b/src/cbmc_starter_kit/setup_ci.py
@@ -5,20 +5,32 @@
 
 """Set up the AWS infrastructure to run proofs in CI."""
 
+import json
 import logging
 import shutil
-from argparse import RawDescriptionHelpFormatter
+from argparse import ArgumentTypeError, RawDescriptionHelpFormatter
 
+import boto3
+import botocore.exceptions
+import git
 
 from cbmc_starter_kit import arguments, repository, util
 
 ################################################################
+
+def is_valid_aws_account_id(aws_account_id):
+    if not aws_account_id or not (aws_account_id.isdigit() and len(aws_account_id) == 12):
+        raise ArgumentTypeError(
+            "AWS account ID is a 12-character string consisting only of digits")
+    return aws_account_id
 
 def parse_arguments():
     """Parse arguments for cbmc-starter-kit-setup-ci command"""
     desc = """
     Copy a GitHub Action workflow to `.github/workflows` in this repository,
     which runs CBMC proofs on every push event.
+    If your project is a public GitHub repo, you can elect to provision
+    infrastructure in AWS, such that you can browse CI artifacts online.
     """
     eplg = """
     The most recently released and available version of a tool (like CBMC, CBMC
@@ -41,6 +53,14 @@ def parse_arguments():
                 The GitHub-hosted runner (operating on Ubuntu 20.04) that will
                 run CBMC proofs in GitHub Actions. If your repo has a large
                 runner available, you can specify it here. default: %(default)s"""
+        }, {
+        'flag': '--aws-account-id',
+        'type': is_valid_aws_account_id,
+        'help': """
+                ID of the AWS account, where AWS CloudFormation stacks will be
+                deployed so that CI artifacts can be viewed online.
+                This option should be used only by public GitHub repositories.
+                """
         }, {
         'flag': '--cbmc',
         'metavar': '<X.Y.Z>',
@@ -77,6 +97,135 @@ def parse_arguments():
 
 ################################################################
 
+def _get_template_body(cf_client, cfn_path, stack_name):
+    template = cfn_path / f"{stack_name}.yaml"
+    with open(template) as template_fileobj:
+        template_data = template_fileobj.read()
+    cf_client.validate_template(TemplateBody=template_data)
+    return template_data
+
+def _stack_exists(cf_client, stack_name):
+    stacks = cf_client.list_stacks()["StackSummaries"]
+    for stack in stacks:
+        if stack["StackStatus"] == "DELETE_COMPLETE":
+            continue
+        if stack_name == stack["StackName"]:
+            return True
+    return False
+
+def _deploy_stack(cf_client, params):
+    """Update or create AWS CloudFormation stack"""
+    stack_name = params["StackName"]
+    try:
+        if _stack_exists(cf_client, stack_name):
+            logging.info("Updating %s", stack_name)
+            stack_result = cf_client.update_stack(**params)
+            waiter = cf_client.get_waiter("stack_update_complete")
+        else:
+            logging.info("Creating %s", stack_name)
+            stack_result = cf_client.create_stack(**params)
+            waiter = cf_client.get_waiter("stack_create_complete")
+        logging.info("Waiting for stack operation to complete...")
+        waiter.wait(StackName=stack_name)
+    except botocore.exceptions.ClientError as ex:
+        error_message = ex.response["Error"]["Message"]
+        if error_message != "No updates are to be performed.":
+            logging.error(
+                "When updating stack %s, unexpected error encountered: %s",
+                stack_name, error_message
+            )
+            raise
+        print(f"No updates are to be performed for stack {stack_name}")
+    else:
+        logging.info("Deployment result for stack '%s':", stack_name)
+        logging.info(json.dumps(stack_result, indent=4))
+
+def _deploy_stacks(cf_client, cfn_path, repo_owner, repo_name, repo_id):
+    """
+    Deploy AWS CloudFormation stacks. Return domain of CloudFront distribution
+    """
+    if not _stack_exists(cf_client, util.CFN_STACK_OIDC):
+        _deploy_stack(
+            cf_client,
+            params={
+                "StackName": util.CFN_STACK_OIDC,
+                "TemplateBody": _get_template_body(
+                    cf_client, cfn_path, util.CFN_STACK_OIDC),
+            },
+        )
+    pipeline_stack = f"{util.CFN_STACK_PIPELINE}-{repo_id}"
+    _deploy_stack(
+        cf_client,
+        params={
+            "StackName": pipeline_stack,
+            "TemplateBody": _get_template_body(
+                    cf_client, cfn_path, util.CFN_STACK_PIPELINE),
+            "Parameters": [
+                {"ParameterKey": k, "ParameterValue": v}
+                for k, v in {
+                    "GitHubRepoOwner": repo_owner,
+                    "GitHubRepoName": repo_name,
+                    "GitHubRepoId": str(repo_id)
+                }.items()
+            ],
+            "Capabilities": ["CAPABILITY_NAMED_IAM"],
+            "Tags": [
+                {"Key": "owner", "Value": repo_owner},
+                {"Key": "repo", "Value": repo_name}
+            ],
+        },
+    )
+
+def deploy(aws_account_id, cfn_path, repo_owner, repo_name, repo_id):
+    """
+    Deploy to AWS the infrastructure in the form of AWS CFN stacks needed to run
+    CBMC proofs as part of CI.
+    """
+    try:
+        sts_client = boto3.client("sts")
+        cf_client = boto3.client("cloudformation")
+        response = sts_client.get_caller_identity()
+        if aws_account_id == response["Account"]:
+            logging.info(
+                "AWS credentials for account %s found", response["Account"])
+            print("Deploying CI infrastructure to AWS CloudFormation...")
+            _deploy_stacks(
+                cf_client, cfn_path, repo_owner, repo_name, repo_id)
+        else:
+            logging.error(
+                "AWS credentials for %s not found", response["Account"])
+    except (
+        botocore.exceptions.ClientError,
+        botocore.exceptions.NoCredentialsError,
+    ) as error:
+        error_message = error.response["Error"]["Message"]
+        logging.exception(
+            "Failed to deploy CI infrastructure: %s", error_message)
+
+def get_pipeline_stack_outputs(repo_id):
+    pipeline_stack = f"{util.CFN_STACK_PIPELINE}-{repo_id}"
+    cf_client = boto3.client("cloudformation")
+    response = cf_client.describe_stacks(StackName=pipeline_stack)
+    return response["Stacks"][0]["Outputs"]
+
+def print_role_arn(pipeline_outputs, repo_owner, repo_name):
+    for output in pipeline_outputs:
+        if output["OutputKey"] == "ProofActionsRoleArn":
+            role_arn = output["OutputValue"]
+            print(
+                "Visit:\n\n"
+                f"https://github.com/{repo_owner}/{repo_name}/settings/secrets/actions\n\n"
+                "and add a \"PROOF_CI_IAM_ROLE\" secret to your repository's "
+                f"secrets used in GitHub Actions.\nThe secret must have this value:\n\n{role_arn}")
+            return
+
+def get_aws_cloudfront_domain(pipeline_outputs):
+    for output in pipeline_outputs:
+        if output["OutputKey"] == "ProofCIDistributionDomainName":
+            return output["OutputValue"]
+
+################################################################
+
 def _replace_placeholders_in_config_template(lines, replacements):
     """Returns a list of new lines, where some lines have had a placeholder
     value appropriately updated."""
@@ -90,12 +239,13 @@ def _replace_placeholders_in_config_template(lines, replacements):
         buf.append(f"{key_lower_kebab}: {replacements[key_upper_snake]}")
     return buf
 
-def patch_proof_ci_config(config, args):
+def patch_proof_ci_config(config, args, domain_name):
     """Patch config for GitHub Actions workflow with appropriate values"""
     with open(config, encoding='utf-8') as data:
         lines = data.read().splitlines()
     proofs_dir = repository.get_relative_path_from_repository_to_proofs_root()
     replacements = {
+        "AWS_CLOUDFRONT_DOMAIN": domain_name,
         "CADICAL_TAG": args.cadical,
         "CBMC_VERSION": args.cbmc,
         "CBMC_VIEWER_VERSION": args.cbmc_viewer,
@@ -141,6 +291,11 @@ def main():
     Creates a GitHub Actions workflow file based on the provided input.
     """
     args = parse_arguments()
+    aws_account_id = args.aws_account_id
+    repo_root = repository.repository_root()
+    repo_url_segments = (
+        git.Repo(repo_root).remotes.origin.url.split(".git")[0].split("/"))
+    repo_owner, repo_name = repo_url_segments[-2], repo_url_segments[-1]
 
     workflows_root = repository.github_actions_workflows_root()
     config = workflows_root / "proof_ci_resources" / "config.yaml"
@@ -151,7 +306,22 @@ def main():
         workflows_root,
         dirs_exist_ok=True)
 
-    patch_proof_ci_config(config, args)
+    # If the workflow is provided with an empty string as the CloudFront domain,
+    # then steps relevant to AWS will not be executed in GitHub Actions
+    domain_name = "''"
+    if aws_account_id:
+        cfn_path = workflows_root / "proof_ci_resources" / "cfn"
+        repo_id = util.get_repo_id(repo_owner, repo_name)
+        deploy(aws_account_id, cfn_path, repo_owner, repo_name, repo_id)
+        pipeline_stack_outputs = get_pipeline_stack_outputs(repo_id)
+        print_role_arn(pipeline_stack_outputs, repo_owner, repo_name)
+        domain_name = get_aws_cloudfront_domain(pipeline_stack_outputs)
+        if not domain_name or domain_name == "''":
+            # Delete templates from target repository
+            for filename in cfn_path.iterdir():
+                filename.unlink()
+
+    patch_proof_ci_config(config, args, domain_name)
     patch_proof_ci_workflow(workflow, args.github_actions_runner)
 
     repo_root = repository.repository_root()

--- a/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
+++ b/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Parse config file
         run: |
           CONFIG_FILE='.github/workflows/proof_ci_resources/config.yaml'
-          for setting in cadical-tag cbmc-version cbmc-viewer-version kissat-tag litani-version proofs-dir run-cbmc-proofs-command; do
+          for setting in aws-cloudfront-domain aws-region aws-role-duration-seconds cadical-tag cbmc-version cbmc-viewer-version kissat-tag litani-version proofs-dir run-cbmc-proofs-command; do
             VAR=$(echo $setting | tr "[:lower:]" "[:upper:]" | tr - _)
             echo "${VAR}"=$(yq .$setting $CONFIG_FILE) >> $GITHUB_ENV
           done
@@ -171,11 +171,40 @@ jobs:
         with:
           name: ${{ steps.artifact.outputs.name }}
           path: ${{ steps.artifact.outputs.name }}.zip
+      - name: Set S3 URI
+        id: s3_uri
+        if: ${{ env.AWS_CLOUDFRONT_DOMAIN != '' }}
+        run: echo "name=BuildArtifacts/${{ github.event.after }}/final" >> $GITHUB_OUTPUT
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        if: ${{ env.AWS_CLOUDFRONT_DOMAIN != '' }}
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-duration-seconds: ${{ env.AWS_ROLE_DURATION_SECONDS }}
+          role-session-name: cbmc_ci
+          role-to-assume: ${{ secrets.PROOF_CI_IAM_ROLE }}
+      - name: Upload CBMC proof results to S3
+        id: aws_upload
+        if: ${{ env.AWS_CLOUDFRONT_DOMAIN != '' }}
+        shell: bash
+        run: |
+          aws s3 sync \
+            $PROOFS_DIR/output/latest/html \
+            s3://proof-ci-artifacts-${{ fromJson(toJson(github.event.repository)).id }}/${{ steps.s3_uri.outputs.name }} \
+            --only-show-errors
       - name: CBMC proof results
         shell: bash
         run: |
-          python3 ${{ env.PROOFS_DIR }}/lib/summarize.py \
-            --run-file ${{ env.PROOFS_DIR }}/output/latest/html/run.json > summary.md
+          if [ -n "${{ env.AWS_CLOUDFRONT_DOMAIN }}" ]
+          then
+            python3 ${{ env.PROOFS_DIR }}/lib/summarize.py \
+              --cloudfront-domain ${{ env.AWS_CLOUDFRONT_DOMAIN }} \
+              --s3-uri ${{ steps.s3_uri.outputs.name }} \
+              --run-file ${{ env.PROOFS_DIR }}/output/latest/html/run.json > summary.md
+          else
+            python3 ${{ env.PROOFS_DIR }}/lib/summarize.py \
+              --run-file ${{ env.PROOFS_DIR }}/output/latest/html/run.json > summary.md
+          fi
           cat summary.md >> $GITHUB_STEP_SUMMARY
           cat summary.md
           cat summary.md | [[ $(grep -cim1 -e "fail" -e "in progress") -eq 0 ]] ; echo $?

--- a/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci_resources/cfn/proof-ci-Oidc.yaml
+++ b/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci_resources/cfn/proof-ci-Oidc.yaml
@@ -1,0 +1,16 @@
+Resources:
+  GithubOIDC:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      ThumbprintList:
+        # Source: https://github.blog/changelog/2022-01-13-github-actions-update-on-oidc-based-deployments-to-aws/
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
+      ClientIdList:
+        - sts.amazonaws.com
+      Url: https://token.actions.githubusercontent.com
+Outputs:
+  GitHubOidcProviderArn:
+    Value:
+      Ref: GithubOIDC
+    Export:
+      Name: GitHubOidcProviderArn

--- a/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci_resources/cfn/proof-ci-Pipeline.yaml
+++ b/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci_resources/cfn/proof-ci-Pipeline.yaml
@@ -1,0 +1,196 @@
+Parameters:
+  GitHubRepoOwner:
+    Type: String
+  GitHubRepoName:
+    Type: String
+  GitHubRepoId:
+    Type: String
+Resources:
+  CiArtifactsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - BucketKeyEnabled: false
+            ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      BucketName:
+        Fn::Join:
+          - "-"
+          - - "proof-ci-artifacts"
+            - Ref: GitHubRepoId
+  ProofActionsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+              StringLike:
+                token.actions.githubusercontent.com:sub:
+                  - Fn::Join:
+                      - ""
+                      - - "repo:"
+                        - Ref: GitHubRepoOwner
+                        - "/"
+                        - Ref: GitHubRepoName
+                        - :*
+            Effect: Allow
+            Principal:
+              Federated:
+                Fn::ImportValue: GitHubOidcProviderArn
+        Version: "2012-10-17"
+      Description: This role is used by GitHub Actions to upload Litani HTML reports.
+      MaxSessionDuration: 7200
+      Policies:
+        - PolicyDocument:
+            Statement:
+              - Action:
+                  - s3:ListBucket
+                Effect: Allow
+                Resource:
+                  Fn::GetAtt:
+                    - CiArtifactsBucket
+                    - Arn
+              - Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Effect: Allow
+                Resource:
+                  Fn::Join:
+                    - ""
+                    - - Fn::GetAtt:
+                          - CiArtifactsBucket
+                          - Arn
+                      - /*
+            Version: "2012-10-17"
+          PolicyName: s3
+      RoleName:
+        Fn::Join:
+          - "-"
+          - - "proof-ci-actions-role"
+            - Ref: GitHubRepoId
+    DependsOn:
+      - CiArtifactsBucket
+  ProofCICloudFrontOriginAccessIdentity:
+    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: Origin Access Identity to be granted read-access to S3 bucket with CI artifacts
+  ProofCICloudFrontOAIPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket:
+        !Ref CiArtifactsBucket
+      PolicyDocument:
+        Statement:
+          - Action: s3:GetObject
+            Effect: Allow
+            Principal:
+              CanonicalUser:
+                Fn::GetAtt:
+                  - ProofCICloudFrontOriginAccessIdentity
+                  - S3CanonicalUserId
+            Resource:
+              Fn::Join:
+                - ""
+                - - Fn::GetAtt:
+                      - CiArtifactsBucket
+                      - Arn
+                  - /*
+        Version: "2012-10-17"
+    DependsOn:
+      - ProofCICloudFrontOriginAccessIdentity
+  ProofCIDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - GET
+            - HEAD
+          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+          CachedMethods:
+            - GET
+            - HEAD
+          Compress: true
+          TargetOriginId:
+            Fn::GetAtt:
+              - ProofCICloudFrontOriginAccessIdentity
+              - Id
+          ViewerProtocolPolicy: redirect-to-https
+        DefaultRootObject: index.html
+        Enabled: true
+        Origins:
+          - ConnectionAttempts: 3
+            ConnectionTimeout: 10
+            DomainName:
+              Fn::Join:
+                - ""
+                - - !Ref CiArtifactsBucket
+                  - .s3.
+                  - Ref: AWS::Region
+                  - .amazonaws.com
+            Id:
+              Fn::GetAtt:
+                - ProofCICloudFrontOriginAccessIdentity
+                - Id
+            OriginShield:
+              Enabled: false
+              OriginShieldRegion:
+                Ref: AWS::Region
+            S3OriginConfig:
+              OriginAccessIdentity:
+                Fn::Join:
+                  - ""
+                  - - origin-access-identity/cloudfront/
+                    - Fn::GetAtt:
+                        - ProofCICloudFrontOriginAccessIdentity
+                        - Id
+    DependsOn:
+      - ProofCICloudFrontOriginAccessIdentity
+Outputs:
+  CiArtifactsS3Bucket:
+    Value:
+      !Ref CiArtifactsBucket
+    Export:
+      Name:
+        Fn::Join:
+          - "-"
+          - - "CiArtifactsS3Bucket"
+            - Ref: GitHubRepoId
+  CiArtifactsS3BucketArn:
+    Value:
+      Fn::GetAtt:
+        - CiArtifactsBucket
+        - Arn
+    Export:
+      Name:
+        Fn::Join:
+          - "-"
+          - - "CiArtifactsS3BucketArn"
+            - Ref: GitHubRepoId
+  ProofActionsRoleArn:
+    Value:
+      Fn::GetAtt:
+        - ProofActionsRole
+        - Arn
+    Export:
+      Name:
+        Fn::Join:
+          - "-"
+          - - "ProofActionsRoleArn"
+            - Ref: GitHubRepoId
+  ProofCIDistributionDomainName:
+    Value:
+      Fn::GetAtt:
+        - ProofCIDistribution
+        - DomainName
+    Export:
+      Name:
+        Fn::Join:
+          - "-"
+          - - "ProofCIDistributionDomainName"
+            - Ref: GitHubRepoId

--- a/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci_resources/config.yaml
+++ b/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci_resources/config.yaml
@@ -1,3 +1,6 @@
+aws-cloudfront-domain: <__AWS_CLOUDFRONT_DOMAIN__>
+aws-region: us-east-1
+aws-role-duration-seconds: 3600
 cadical-tag: <__CADICAL_TAG__>
 cbmc-version: <__CBMC_VERSION__>
 cbmc-viewer-version: <__CBMC_VIEWER_VERSION__>

--- a/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
@@ -8,19 +8,41 @@ import logging
 
 DESCRIPTION = """Print 2 tables in GitHub-flavored Markdown that summarize
 an execution of CBMC proofs."""
+EPILOG = """The CloudFront domain and the S3 URI should either be specified
+ together or they should not be specified altogether."""
 
 
 def get_args():
     """Parse arguments for summarize script."""
-    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG)
     for arg in [{
             "flags": ["--run-file"],
             "help": "path to the Litani run.json file",
             "required": True,
+        }, {
+            "flags": ["--cloudfront-domain"],
+            "help": "the domain of the Amazon CloudFront distribution that is "
+                    "serving CBMC proof reports, which were uploaded to S3"
+                    "during the execution of the GitHub Actions workflow."
+                    "Usage of this flag necessitates usage of --s3-uri"
+                    "For example: d111111abcdef8.cloudfront.net"
+        }, {
+            "flags": ["--s3-uri"],
+            "help": "the key to a directory within a S3 bucket holding all "
+                    "artifacts for a CBMC proof report."
+                    "Usage of this flag necessitates usage of --cloudfront-domain"
+                    "For example: BuildArtifacts/abcdef/final"
     }]:
         flags = arg.pop("flags")
         parser.add_argument(*flags, **arg)
-    return parser.parse_args()
+    args = parser.parse_args()
+    with_aws = args.cloudfront_domain and args.s3_uri
+    without_aws = not args.cloudfront_domain and not args.s3_uri
+    if not (with_aws or without_aws):
+        parser.error(
+            "The CloudFront domain and the S3 URI should either be specified "
+            "together or they should not be specified altogether.")
+    return args
 
 
 def _get_max_length_per_column_list(data):
@@ -65,7 +87,7 @@ def _get_rendered_table(data):
     return "".join(table)
 
 
-def _get_status_and_proof_summaries(run_dict):
+def _get_status_and_proof_summaries(run_dict, cloudfront_domain=None, s3_uri=None):
     """Parse a dict representing a Litani run and create lists summarizing the
     proof results.
 
@@ -73,7 +95,14 @@ def _get_status_and_proof_summaries(run_dict):
     ----------
     run_dict
         A dictionary representing a Litani run.
-
+    cloudfront_domain
+        A string representing the domain of the CloudFront distribution, which
+        serves CBMC proof results that areuploaded to an associated S3 bucket.
+        For example: d111111abcdef8.cloudfront.net
+    s3_uri
+        The key to a directory within a S3 bucket holding all artifacts for a
+        CBMC proof report.
+        For example: BuildArtifacts/abcdef/final
 
     Returns
     -------
@@ -83,6 +112,8 @@ def _get_status_and_proof_summaries(run_dict):
     """
     count_statuses = {}
     proofs = [["Proof", "Status"]]
+    if cloudfront_domain:
+        proofs[0].append("CBMC proof report")
     for proof_pipeline in run_dict["pipelines"]:
         status_pretty_name = proof_pipeline["status"].title().replace("_", " ")
         try:
@@ -91,13 +122,20 @@ def _get_status_and_proof_summaries(run_dict):
             count_statuses[status_pretty_name] = 1
         proof = proof_pipeline["name"]
         proofs.append([proof, status_pretty_name])
+    if cloudfront_domain:
+        for i in range(1, len(proofs)):
+            proof = proofs[i][0]
+            final_report = f"https://{cloudfront_domain}/{s3_uri}"
+            viewer_proof_artifact = f"artifacts/{proof}/report/html/index.html"
+            viewer_html_report_url = f"{final_report}/{viewer_proof_artifact}"
+            proofs[i].append(f"[Details]({viewer_html_report_url})")
     statuses = [["Status", "Count"]]
     for status, count in count_statuses.items():
         statuses.append([status, str(count)])
     return [statuses, proofs]
 
 
-def print_proof_results(out_file):
+def print_proof_results(out_file, cloudfront_domain=None, s3_uri=None):
     """
     Print 2 strings that summarize the proof results.
     When printing, each string will render as a GitHub flavored Markdown table.
@@ -107,7 +145,7 @@ def print_proof_results(out_file):
         with open(out_file, encoding='utf-8') as run_json:
             run_dict = json.load(run_json)
             summaries = _get_status_and_proof_summaries(
-                run_dict)
+                run_dict, cloudfront_domain=cloudfront_domain, s3_uri=s3_uri)
             for summary in summaries:
                 print(_get_rendered_table(summary))
     except Exception as ex: # pylint: disable=broad-except
@@ -116,4 +154,14 @@ def print_proof_results(out_file):
 
 if __name__ == '__main__':
     args = get_args()
-    print_proof_results(args.run_file)
+    without_aws = not args.cloudfront_domain and not args.s3_uri
+    if without_aws:
+        print_proof_results(args.run_file)
+        exit(0)
+    CBMC_PROOF_REPORT_HEADER = "Click here to see the CBMC proof report"
+    url = f"https://{args.cloudfront_domain}/{args.s3_uri}/index.html"
+    print(f"## [{CBMC_PROOF_REPORT_HEADER}]({url})")
+    print_proof_results(
+        args.run_file,
+        cloudfront_domain=args.cloudfront_domain,
+        s3_uri=args.s3_uri)

--- a/src/cbmc_starter_kit/util.py
+++ b/src/cbmc_starter_kit/util.py
@@ -4,7 +4,11 @@
 """Methods of manipulating the templates repository."""
 
 import importlib.util
+import json
+import sys
 from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
 
 from cbmc_starter_kit import repository
 
@@ -74,6 +78,33 @@ def package_proof_template_root():
 
 def package_ci_workflow_template_root():
     return package_root() / CI_WORKFLOW_TEMPLATES
+
+def _get_repository_details(repo_owner, repo_name):
+    endpoint = f"https://api.github.com/repos/{repo_owner}/{repo_name}"
+    try:
+        with urlopen(endpoint, timeout=10) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as error:
+        print(error.status, error.reason)
+        if error.status == 403:
+            print(f"You don't have access to {repo_owner}/{repo_name}")
+        elif error.status == 404:
+            print(
+                f"{repo_owner}/{repo_name} is either private or doesn't exist")
+            print(
+                "If the repository is private, please run "
+                "`cbmc-starter-kit-setup-ci` without providing an AWS account")
+        sys.exit(1)
+    except URLError as error:
+        print(error.reason)
+        sys.exit(1)
+    except TimeoutError:
+        print("Request timed out")
+        sys.exit(1)
+
+def get_repo_id(repo_owner, repo_name):
+    repo_details = _get_repository_details(repo_owner, repo_name)
+    return repo_details["id"]
 
 ################################################################
 # Ask the user for set up information


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This PR is a followup to https://github.com/model-checking/cbmc-starter-kit/pull/152

The GitHub Actions workflow, which handles the execution of CBMC proofs in CI, can now optionally upload results to S3 and make them available for online browsing via CloudFront (assuming that the developer, who is responsible for setting up the CI, will provide their AWS account ID during setup).

Just like before CBMC proofs are executed inside of the GitHub Actions runner. Artifacts from the execution of CBMC proofs are uploaded to a bucket in S3. Due to fact that this bucket is "associated" to a CloudFront distribution, users are able to browse online all related artifacts. A user only needs to click on the CBMC proof report link, which is present both in the logs of the GitHub Actions workflow and in the "summary" page of the corresponding GitHub Actions job.

[This PR in my fork of aws/s2n-tls](https://github.com/angelonakos/s2n-tls/pull/17) serves as a demonstration of the changes here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.