### PR TITLE
Add kissat to list of tools whose version can be printed out

### DIFF
--- a/src/cbmc_starter_kit/print_tool_versions.py
+++ b/src/cbmc_starter_kit/print_tool_versions.py
@@ -15,6 +15,7 @@ _TOOLS = [
     "cbmc",
     "cbmc-viewer",
     "cbmc-starter-kit-update",
+    "kissat",
     "litani",
 ]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

#156 missed `kissat` as one of the tools, whose version can be printed out via the newly introduced CBMC starter kit command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
