### PR TITLE
Version GitHub Actions workflow file

### DIFF
--- a/src/cbmc_starter_kit/setup_ci.py
+++ b/src/cbmc_starter_kit/setup_ci.py
@@ -10,7 +10,7 @@ import shutil
 from argparse import RawDescriptionHelpFormatter
 
 
-from cbmc_starter_kit import arguments, repository, util
+from cbmc_starter_kit import arguments, repository, util, version
 
 ################################################################
 
@@ -153,6 +153,7 @@ def main():
 
     patch_proof_ci_config(config, args)
     patch_proof_ci_workflow(workflow, args.github_actions_runner)
+    version.copy_with_version(workflow, workflow)
 
     repo_root = repository.repository_root()
     copy_lib_directory(repo_root)

--- a/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
+++ b/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
+# _CBMC_STARTER_KIT_VERSION_
 name: Run CBMC proofs
 on:
   push:

--- a/src/cbmc_starter_kit/update.py
+++ b/src/cbmc_starter_kit/update.py
@@ -11,9 +11,7 @@ import platform
 import re
 import shutil
 
-from cbmc_starter_kit import arguments
-from cbmc_starter_kit import util
-from cbmc_starter_kit import version
+from cbmc_starter_kit import arguments, repository, util, version
 
 ################################################################
 
@@ -118,6 +116,13 @@ def check_for_litani(cbmc_root):
                         "https://github.com/awslabs/aws-build-accumulator/releases/latest")
     return
 
+def check_for_proof_ci_workflow():
+    workflow_root = repository.github_actions_workflows_root()
+    path_to_workflow_in_customer_repo = workflow_root / "proof_ci.yaml"
+    if path_to_workflow_in_customer_repo.exists():
+        version.update_existing_version_in_workflow_file(
+            path_to_workflow_in_customer_repo)
+
 ################################################################
 
 def main():
@@ -134,6 +139,8 @@ def main():
     if not args.no_update:
         update(args.cbmc_root)
     check_for_litani(args.cbmc_root)
+    check_for_proof_ci_workflow()
+
 
 ################################################################
 

--- a/src/cbmc_starter_kit/version.py
+++ b/src/cbmc_starter_kit/version.py
@@ -3,6 +3,8 @@
 
 """Version number."""
 
+import os
+
 NAME = "CBMC starter kit"
 NUMBER = "2.8.8"
 VERSION = f"{NAME} {NUMBER}"
@@ -21,3 +23,13 @@ def copy_with_version(src, dst):
         data = srcfile.read()
     with open(dst, 'w', encoding='utf-8') as dstfile:
         dstfile.write(data.replace(REPLACE_TARGET, version()))
+
+def update_existing_version_in_workflow_file(workflow):
+    tmp_file = f"{workflow}~"
+    with open(workflow) as src, open(tmp_file, "w") as dst:
+        for line in src:
+            if line.startswith(f"# {NAME}"):
+                print(version(), file=dst)
+            else:
+                print(line, file=dst)
+    os.rename(tmp_file, workflow)


### PR DESCRIPTION
*Issue #, if available:*

#173 

*Description of changes:*

If a target proof-project repository lacks the GitHub Actions workflow file, when the user runs the `cbmc-starter-kit-setup-ci` the comment in the template will be updated to reflect the version of the CBMC starter kit that "introduces" the workflow file to a target repository.

If the target proof-project already contains the GitHub Actions file to run CBMC proofs, then the comment indicating the version of the CBMC starter kit is being appropriately updated.

For example, assume repository X has version X.Y.Z mentioned near the top of the ProofCI workflow file and that version A.B happens to be the latest semantic version of the CBMC starter kit. During a CBMC upgrade, the comment in the workflow file will be updated to reflect version A.B

Testing:

If I change the version in `setup.cfg` and `src/cbmc_starter_kit/version.py` to 2.8.11 and run `cbmc-starter-kit-setup-ci` in a target proof project, the resulting workflow file for the ProofCI GitHub Action will contain a comment in the top indicating the version - 2.8.11 in thie case - of the CBMC starter kit that was used to introduce the workflow file. If I change the version to 2.23 and re-build the package and attempt to update a proof-project that contains the workflow file, then the version will change from 2.8.11 to 2.23

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
