### PR TITLE
Enable execution of ProofCI GItHub Action for more events

### DIFF
--- a/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
+++ b/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches-ignore:
       - gh-pages
+  pull_request:
+    branches-ignore:
+      - gh-pages
 
 # USAGE
 #

--- a/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
+++ b/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches-ignore:
       - gh-pages
+  workflow_dispatch:
 
 # USAGE
 #


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

More specifically, CBMC proofs can now be executed when a fork opens a PR against an "upstream" repository. Additionally, CBMC proofs can also be executed manually on-demand as soon as the workflow has been added to a repository's main branch.


![image](https://user-images.githubusercontent.com/3038292/211598213-ce614c04-529e-4a09-96b4-45d5ad849d56.png)

This screenshot illustrates the ability to execute the "Run CBMC proofs" workflow manually (previously this would run only on push events).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
