### PR TITLE
Direct users to GitHub Actions summary page

### DIFF
--- a/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
+++ b/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
@@ -175,7 +175,4 @@ jobs:
         shell: bash
         run: |
           python3 ${{ env.PROOFS_DIR }}/lib/summarize.py \
-            --run-file ${{ env.PROOFS_DIR }}/output/latest/html/run.json > summary.md
-          cat summary.md >> $GITHUB_STEP_SUMMARY
-          cat summary.md
-          cat summary.md | [[ $(grep -cim1 -e "fail" -e "in progress") -eq 0 ]] ; echo $?
+            --run-file ${{ env.PROOFS_DIR }}/output/latest/html/run.json

--- a/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
@@ -97,23 +97,22 @@ def _get_status_and_proof_summaries(run_dict):
     return [statuses, proofs]
 
 
-def print_proof_results(out_file):
+def main(out_file):
     """
     Print 2 strings that summarize the proof results.
     When printing, each string will render as a GitHub flavored Markdown table.
     """
     print("## Summary of CBMC proof results")
-    try:
-        with open(out_file, encoding='utf-8') as run_json:
-            run_dict = json.load(run_json)
-            summaries = _get_status_and_proof_summaries(
-                run_dict)
-            for summary in summaries:
-                print(_get_rendered_table(summary))
-    except Exception as ex: # pylint: disable=broad-except
-        logging.critical("Could not print results. Exception: %s", str(ex))
+    with open(out_file, encoding='utf-8') as run_json:
+        run_dict = json.load(run_json)
+    summaries = _get_status_and_proof_summaries(run_dict)
+    for summary in summaries:
+        print(_get_rendered_table(summary))
 
 
 if __name__ == '__main__':
     args = get_args()
-    print_proof_results(args.run_file)
+    try:
+        main(args.run_file)
+    except Exception as ex: # pylint: disable=broad-except
+        logging.critical("Could not print results. Exception: %s", str(ex))

--- a/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
@@ -112,6 +112,7 @@ def print_proof_results(out_file):
         output += _get_rendered_table(summary)
 
     print(output)
+    sys.stdout.flush()
 
     github_summary_file = os.getenv("GITHUB_STEP_SUMMARY")
     if github_summary_file:
@@ -122,15 +123,22 @@ def print_proof_results(out_file):
         logging.warning(
             "$GITHUB_STEP_SUMMARY not set, not writing summary file")
 
+    msg = (
+        "Click the 'Summary' button to view a Markdown table "
+        "summarizing all proof results")
     not_passed = [
         (status, count) for (status, count) in status_table[1:]
         if count and (status != "Success")]
     if not_passed:
+        logging.error("Not all proofs passed.")
+        logging.error(msg)
         sys.exit(1)
+    logging.info(msg)
 
 
 if __name__ == '__main__':
     args = get_args()
+    logging.basicConfig(format="%(levelname)s: %(message)s")
     try:
         print_proof_results(args.run_file)
     except Exception as ex: # pylint: disable=broad-except

--- a/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
@@ -127,10 +127,7 @@ def print_proof_results(out_file):
     msg = (
         "Click the 'Summary' button to view a Markdown table "
         "summarizing all proof results")
-    not_passed = [
-        (status, count) for (status, count) in status_table[1:]
-        if count and (status != "Success")]
-    if not_passed:
+    if run_dict["status"] != "success":
         logging.error("Not all proofs passed.")
         logging.error(msg)
         sys.exit(1)

--- a/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
@@ -91,8 +91,9 @@ def _get_status_and_proof_summaries(run_dict):
             count_statuses[status_pretty_name] += 1
         except KeyError:
             count_statuses[status_pretty_name] = 1
-        proof = proof_pipeline["name"]
-        proofs.append([proof, status_pretty_name])
+        if proof_pipeline["name"] == "print_tool_versions":
+            continue
+        proofs.append([proof_pipeline["name"], status_pretty_name])
     statuses = [["Status", "Count"]]
     for status, count in count_statuses.items():
         statuses.append([status, str(count)])

--- a/test/summarize_test/summarize_test.py
+++ b/test/summarize_test/summarize_test.py
@@ -18,23 +18,23 @@ class TestSummarizeResults(unittest.TestCase):
 
     @unittest.mock.patch('builtins.print')
     def test_print_proof_results(self, mock):
-        summarize.print_proof_results(self.run_file)
+        with self.assertRaises(SystemExit):
+            summarize.print_proof_results(self.run_file)
         expected_calls = [
-            unittest.mock.call("## Summary of CBMC proof results"),
             unittest.mock.call(
+                "## Summary of CBMC proof results\n\n"
                 "| Status  | Count |\n"
                 "|---------|-------|\n"
                 "| Fail    | 1     |\n"
                 "| Success | 1     |\n"
-                "\n"),
-            unittest.mock.call(
+                "\n"
                 "| Proof             | Status  |\n"
                 "|-------------------|---------|\n"
                 "| pipe-will-fail    | Fail    |\n"
                 "| pipe-will-succeed | Success |\n"
                 "\n")
         ]
-        self.assertEqual(expected_calls, mock.call_args_list)
+        self.assertEqual(expected_calls[0], mock.call_args_list[0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`summarize.py` now directs users to view the "Summary" page if they are reading the `summarize.py` output in the GitHub Action Log. The summary page has a Markdown-formatted summary of proof results.

This resolves #183. It also resolves #177


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
