### PR TITLE
Check repo visibility before uploading report

### DIFF
--- a/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
+++ b/src/cbmc_starter_kit/template-for-ci-workflow/proof_ci.yaml
@@ -156,13 +156,18 @@ jobs:
           EXTERNAL_SAT_SOLVER: kissat
         working-directory: ${{ env.PROOFS_DIR }}
         run: ${{ env.RUN_CBMC_PROOFS_COMMAND }}
+      - name: Check repository visibility
+        shell: bash
+        run: |
+          VIZ="${{ fromJson(toJson(github.event.repository)).visibility }}";
+          echo "REPO_VISIBILITY=${VIZ}" | tee -a "${GITHUB_ENV}";
       - name: Set name for zip artifact with CBMC proof results
         id: artifact
-        if: ${{ env.AWS_CLOUDFRONT_DOMAIN == '' }}
+        if: ${{ env.REPO_VISIBILITY == 'public' }}
         run: |
           echo "name=cbmc_proof_results_${{ fromJson(toJson(github.event.repository)).name }}_$(date +%Y_%m_%d_%H_%M_%S)" >> $GITHUB_OUTPUT
       - name: Create zip artifact with CBMC proof results
-        if: ${{ env.AWS_CLOUDFRONT_DOMAIN == '' }}
+        if: ${{ env.REPO_VISIBILITY == 'public' }}
         shell: bash
         run: |
           FINAL_REPORT_DIR=$PROOFS_DIR/output/latest/html
@@ -171,7 +176,7 @@ jobs:
             && popd \
             && mv $FINAL_REPORT_DIR/${{ steps.artifact.outputs.name }}.zip .
       - name: Upload zip artifact of CBMC proof results to GitHub Actions
-        if: ${{ env.AWS_CLOUDFRONT_DOMAIN == '' }}
+        if: ${{ env.REPO_VISIBILITY == 'public' }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.artifact.outputs.name }}


### PR DESCRIPTION
When using this flag, the proofs will run as normal and a summary will be printed out in the GitHub Action run summary page. However, a zip file of the proof report is not uploaded to GitHub.

* [Run](https://github.com/karkhaz/coreMQTT-Agent/actions/runs/4165819016/jobs/7209342408) for [this commit](https://github.com/karkhaz/coreMQTT-Agent/commit/b751cafd182ae4dcae44cd2a1fd3c32b0eb5fd11) that sets `upload-reports: true`.
* [Run](https://github.com/karkhaz/coreMQTT-Agent/actions/runs/4165893149/jobs/7209513648) for [this commit](https://github.com/karkhaz/coreMQTT-Agent/commit/6187434bd95f530725c9add4646a7d8926f190c8) that sets `upload-reports: false`.

In the second run, three steps of the action are skipped.

![Screen Shot 2023-02-13 at 17 07 40](https://user-images.githubusercontent.com/2887605/218524537-99d5944d-78ca-4920-82b2-5e97096b78bb.png)

This fixes #192.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
