### PR TITLE
Fix off-by-one error in proof summary count

### DIFF
--- a/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
+++ b/src/cbmc_starter_kit/template-for-repository/proofs/lib/summarize.py
@@ -86,13 +86,13 @@ def _get_status_and_proof_summaries(run_dict):
     count_statuses = {}
     proofs = [["Proof", "Status"]]
     for proof_pipeline in run_dict["pipelines"]:
+        if proof_pipeline["name"] == "print_tool_versions":
+            continue
         status_pretty_name = proof_pipeline["status"].title().replace("_", " ")
         try:
             count_statuses[status_pretty_name] += 1
         except KeyError:
             count_statuses[status_pretty_name] = 1
-        if proof_pipeline["name"] == "print_tool_versions":
-            continue
         proofs.append([proof_pipeline["name"], status_pretty_name])
     statuses = [["Status", "Count"]]
     for status, count in count_statuses.items():


### PR DESCRIPTION
*Description of changes:*

We were claiming one more successful proof than we actually had for successful execution of "print_tool_versions" was also counted as a proof.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
