### PR TITLE
Remove double dash from brew bottled archives

### DIFF
--- a/.github/workflows/release-brew.yaml
+++ b/.github/workflows/release-brew.yaml
@@ -139,6 +139,8 @@ jobs:
       - name: Get Package Path
         id: get_package_path
         run: |
+          double_dash_bottle=$(ls *.tar.gz)
+          mv $double_dash_bottle $(echo $double_dash_bottle | sed 's/--/-/')
           echo "bottle_name=$(ls *.tar.gz)" >> $GITHUB_OUTPUT
 
       - name: Upload bottles as artifact


### PR DESCRIPTION
See
https://github.com/orgs/Homebrew/discussions/4541#discussioncomment-6033307 for why those appear. This is to preempt what we saw in https://github.com/model-checking/cbmc-viewer/issues/192.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
